### PR TITLE
Fix Korean filename encoding problem

### DIFF
--- a/content/en/meeting/26th/_index.md
+++ b/content/en/meeting/26th/_index.md
@@ -15,16 +15,16 @@ description: >
 
 ## Agenda
 
-| Time         | Agenda                                                                 | Speaker                                      | Slide |
-|--------------|-----------------------------------------------------------------------|----------------------------------------------|-------|
-| 14:00~14:10  | Welcome & Opening                                                     | Suhong Park, Samsung Electronics             | -     |
-| 14:10~14:30  | OpenChain Global Update                                               | Shane Coughlan, Linux Foundation             | [pptx](../../../slides/korea-wg-2025-06.pptx)   |
-| 14:30~14:40  | OpenChain Korea Update                                                | Haksung Jang, SK Telecom                    | [slide](https://gamma.app/docs/25-2-Update-p2oogyv44st07nj)    |
-| 14:40~15:10  | Samsung Electronics Open Source 2025     | Darae Ahn, Samsung Electronics               | [pptx](../../../slides/삼성전자_오픈소스2025_안다래.pptx)   |
-| 15:10~15:50  | Networking                                                           | All                                          | -     |
-| 15:50~16:20  | AI Data Compliance Process                                            | Jungwon Cho, LG AI Research Institute        | [pptx](../../../slides/AI_Compliance_LG_AI_Research_0613.pdf)    |
-| 16:20~16:50  | Lightning Talk  <br> - Risks When Using Open AI Models in Enterprises <br> - Changes in Redis Licensing and Its Impact on the Open Source Ecosystem |  - Yunhwan Jung, Samsung Electronics<br>  - Jungsook Park, ETRI | <br> [pptx](../../../slides/오픈AI모델리스크_오픈체인KWG_250616.pptx) <br> [pptx](../../../slides/OpenChain-KWG-Redis라이선스변화-20250616-R2.pdf)  |
-| 16:50~17:00 | Closing | - | - |
+| Time         | Agenda                               | Speaker                                      | Slide |
+|--------------|--------------------------------------|----------------------------------------------|-------|
+| 14:00~14:10  | Welcome & Opening                    | Suhong Park, Samsung Electronics             | -     |
+| 14:10~14:30  | OpenChain Global Update              | Shane Coughlan, Linux Foundation             | [pptx](../../../slides/korea-wg-2025-06.pptx) |
+| 14:30~14:40  | OpenChain Korea Update               | Haksung Jang, SK Telecom                     | [slide](https://gamma.app/docs/25-2-Update-p2oogyv44st07nj) |
+| 14:40~15:10  | Samsung Electronics Open Source 2025 | Darae Ahn, Samsung Electronics               | [pptx](../../../slides/삼성전자_오픈소스2025_안다래.pptx) |
+| 15:10~15:50  | Networking                           | All                                          | -     |
+| 15:50~16:20  | AI Data Compliance Process           | Jungwon Cho, LG AI Research Institute        | [pdf](../../../slides/AI_Compliance_LG_AI_Research_0613.pdf) |
+| 16:20~16:50  | Lightning Talk  <br> - Risks When Using Open AI Models in Enterprises <br> - Changes in Redis Licensing and Its Impact on the Open Source Ecosystem |  - Yunhwan Jung, Samsung Electronics<br>  - Jungsook Park, ETRI | <br> [pptx](../../../slides/오픈AI모델리스크_오픈체인KWG_250616.pptx) <br> [pdf](../../../slides/OpenChain-KWG-Redis라이선스변화-20250616-R2.pdf)  |
+| 16:50~17:00 | Closing                               | -                                            | - |
 
 ## Sponsor
 

--- a/content/ko/meeting/26th/_index.md
+++ b/content/ko/meeting/26th/_index.md
@@ -15,16 +15,16 @@ description: >
 
 ## 아젠다
 
-| Time | Agenda           | Speaker | Slide |
-|----|-----------------|------|------|
-| 14:00~14:10 | Welcome & Opening | 삼성전자 박수홍 그룹장 | - |
-| 14:10~14:30 | OpenChain Global Update  | 	Shane Coughlan, Linux Foundation | [pptx](../../slides/korea-wg-2025-06.pptx) |
-| 14:30~14:40 | OpenChain Korea Update | SK텔레콤 장학성 | [slide](https://gamma.app/docs/25-2-Update-p2oogyv44st07nj)    |
-| 14:40~15:10 | 삼성전자 오픈소스 2025 | 삼성전자 안다래 | [pptx](../../slides/삼성전자_오픈소스2025_안다래.pptx)   |
-| 15:10~15:50 | Networking | All | - |
-| 15:50~16:20 | AI 데이터 컴플라이언스 프로세스 | LG AI연구원 조정원 |  [pdf](../../slides/AI_Compliance_LG_AI_Research_0613.pdf)    |
-| 16:20~16:50 | Lightning Talk  <br> - 기업의 개방형 AI 모델 사용 시 리스크 <br> - Redis 라이선스의 변화와 오픈소스 생태계에 미치는 영향 | <br> - 삼성전자 정윤환 <br> - ETRI 박정숙 | <br> [pptx](../../slides/오픈AI모델리스크_오픈체인KWG_250616.pptx) <br> [pdf](../../slides/OpenChain-KWG-Redis라이선스변화-20250616-R2.pdf)  |
-| 16:50~17:00 | Closing | - | - |
+| Time        | Agenda                        | Speaker                          | Slide |
+|-------------|-------------------------------|----------------------------------|-------|
+| 14:00~14:10 | Welcome & Opening             | 삼성전자 박수홍 그룹장             | -     |
+| 14:10~14:30 | OpenChain Global Update       | Shane Coughlan, Linux Foundation | [pptx](../../slides/korea-wg-2025-06.pptx) |
+| 14:30~14:40 | OpenChain Korea Update        | SK텔레콤 장학성                   | [slide](https://gamma.app/docs/25-2-Update-p2oogyv44st07nj) |
+| 14:40~15:10 | 삼성전자 오픈소스 2025         | 삼성전자 안다래                    | [pptx](../../slides/삼성전자_오픈소스2025_안다래.pptx) |
+| 15:10~15:50 | Networking                    | All                              | -     |
+| 15:50~16:20 | AI 데이터 컴플라이언스 프로세스 | LG AI연구원 조정원                | [pdf](../../slides/AI_Compliance_LG_AI_Research_0613.pdf) |
+| 16:20~16:50 | Lightning Talk  <br> - 기업의 개방형 AI 모델 사용 시 리스크 <br> - Redis 라이선스의 변화와 오픈소스 생태계에 미치는 영향 | <br> - 삼성전자 정윤환 <br> - ETRI 박정숙 | <br> [pptx](../../slides/오픈AI모델리스크_오픈체인KWG_250616.pptx) <br> [pdf](../../slides/OpenChain-KWG-Redis라이선스변화-20250616-R2.pdf)  |
+| 16:50~17:00 | Closing                       | -                                | -     |
 
 ## Sponsor
 


### PR DESCRIPTION
@haksungjang

페이지(md)를 macOS 에서 편집하셔서 일부 발표파일의 파일경로 내 존재하는 한글이 조합형(NFD)으로 적용된 것 같습니다. 이를 완성형(NFC)으로 변경하였습니다. (#198 과 동일한 이슈)