### PR TITLE
docs(meeting): 30th 미팅 아젠다 작성 (ko/en)

### DIFF
--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -3,7 +3,7 @@ title: "30th Meeting"
 weight: 30
 type: docs
 categories: ["meeting"]
-tags: ["OpenChain"]
+tags: ["OpenChain", "AI", "governance", "Finance", "KakaoBank"]
 description: >
  Tuesday, June 9, 2026 / KakaoBank
 aliases:
@@ -14,6 +14,19 @@ aliases:
 
 - Date & Time: 2026-06-09 (Tue) 2:00 PM – 5:00 PM
 - Location: KakaoBank (Parc.1 Tower, 108 Yeoui-daero, Yeongdeungpo-gu, Seoul, Republic of Korea  - https://maps.app.goo.gl/kiA47oQHq3g2jkLd6 )
+
+## Agenda
+
+| Time        | Agenda                                              | Speaker                          | Slide |
+|-------------|-----------------------------------------------------|----------------------------------|-------|
+| 14:00~14:10 | Welcome & Introduction                              | Steering Committee               | - |
+| 14:10~14:30 | OpenChain Updates                                   | Steering Committee               | - |
+| 14:30~14:55 | Session1: AI-driven Open Source Governance          | Heonkwan Ha, KakaoBank           | - |
+| 14:55~15:15 | Break & Networking                                  | -                                | - |
+| 15:15~15:40 | Session2: The Impact of Claude Mythos on Open Source | Kangbo Kim, AhnLab               | - |
+| 15:40~16:05 | Session3: Open Source Checklist Analysis for Financial Sector Audits | KakaoBank | - |
+| 16:05~16:50 | Group Discussion                                    | All                              | - |
+| 16:50~17:00 | Closing & Group Photo                               | Steering Committee               | - |
 
 
 ## Sponsor

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -3,7 +3,7 @@ title: "30th Meeting"
 weight: 30
 type: docs
 categories: ["meeting"]
-tags: ["OpenChain"]
+tags: ["OpenChain", "AI", "governance", "금융", "KakaoBank"]
 description: >
  2026년 6월 9일 (화) / 카카오뱅크
 aliases:
@@ -14,6 +14,19 @@ aliases:
 
 * 일정: 2026-06-09 (화) 오후 2시~5시
 * 장소: 카카오뱅크 (여의도 파크원 타워2 35층 - https://maps.app.goo.gl/kiA47oQHq3g2jkLd6 )
+
+## 아젠다
+
+| Time        | Agenda                                              | Speaker                          | Slide |
+|-------------|-----------------------------------------------------|----------------------------------|-------|
+| 14:00~14:10 | 인사 및 참석자 소개                                  | 운영진                           | - |
+| 14:10~14:30 | OpenChain Updates                                   | 운영진                           | - |
+| 14:30~14:55 | Session1: AI-driven Open Source Governance           | 하헌관, 카카오뱅크                | - |
+| 14:55~15:15 | 휴식 및 네트워킹                                     | -                                | - |
+| 15:15~15:40 | Session2: Claude Mythos가 Open Source에 미치는 영향   | 김강보, 안랩                     | - |
+| 15:40~16:05 | Session3: 금융권 감사 대비 오픈소스 체크리스트 분석     | 카카오뱅크                       | - |
+| 16:05~16:50 | 그룹 토의                                            | All                              | - |
+| 16:50~17:00 | 마무리 및 단체 사진 촬영                              | 운영진                           | - |
 
 
 ## Sponsor


### PR DESCRIPTION
## Summary
- 카카오뱅크 호스팅 30th 미팅(2026-06-09) 아젠다 작성
- 세션 3건 구성: AI-driven Open Source Governance(하헌관) · Claude Mythos가 Open Source에 미치는 영향(김강보) · 금융권 감사 대비 오픈소스 체크리스트 분석(카카오뱅크)
- 휴식 20분(Session1 직후) · 그룹 토의 45분 확보
- 한국어/영문 동시 반영, 태그 갱신(AI · governance · 금융 · KakaoBank)

## Test plan
- [ ] hugo server -D 로컬 미리보기에서 ko/en 30th 페이지 렌더링 확인
- [ ] 아젠다 표 시간순 일치 여부 확인
- [ ] 발표자명·세션 제목 오기 확인