### PR TITLE
docs(meeting): restyle 30th meeting pages (ko/en)

### DIFF
--- a/content/en/meeting/2019/_index.md
+++ b/content/en/meeting/2019/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2019"
 linkTitle: "2019"
-weight: 2019
+weight: 7981
 type: docs
 description: >
   OpenChain KWG meetings held in 2019 (1st ~ 4th)

--- a/content/en/meeting/2020/_index.md
+++ b/content/en/meeting/2020/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2020"
 linkTitle: "2020"
-weight: 2020
+weight: 7980
 type: docs
 description: >
   OpenChain KWG meetings held in 2020 (5th ~ 8th)

--- a/content/en/meeting/2021/_index.md
+++ b/content/en/meeting/2021/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2021"
 linkTitle: "2021"
-weight: 2021
+weight: 7979
 type: docs
 description: >
   OpenChain KWG meetings held in 2021 (9th ~ 12nd)

--- a/content/en/meeting/2022/_index.md
+++ b/content/en/meeting/2022/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2022"
 linkTitle: "2022"
-weight: 2022
+weight: 7978
 type: docs
 description: >
   OpenChain KWG meetings held in 2022 (13th ~ 16th)

--- a/content/en/meeting/2023/_index.md
+++ b/content/en/meeting/2023/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2023"
 linkTitle: "2023"
-weight: 2023
+weight: 7977
 type: docs
 description: >
   OpenChain KWG meetings held in 2023 (17th ~ 20th)

--- a/content/en/meeting/2024/_index.md
+++ b/content/en/meeting/2024/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2024"
 linkTitle: "2024"
-weight: 2024
+weight: 7976
 type: docs
 description: >
   OpenChain KWG meetings held in 2024 (21st ~ 24th)

--- a/content/en/meeting/2025/_index.md
+++ b/content/en/meeting/2025/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2025"
 linkTitle: "2025"
-weight: 2025
+weight: 7975
 type: docs
 description: >
   OpenChain KWG meetings held in 2025 (25th ~ 28th)

--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -10,26 +10,99 @@ aliases:
   - /en/meeting/30th/
 ---
 
-## Schedule
+<div style="padding:26px;border-radius:18px;background:linear-gradient(135deg,#ffe812 0%,#ffd400 45%,#ffb800 100%);color:#1a1500;margin-bottom:14px;box-shadow:0 12px 28px rgba(255,184,0,.35);">
+  <p style="margin:0 0 8px 0;letter-spacing:.08em;font-size:12px;font-weight:700;opacity:.75;">OPENCHAIN KOREA WORK GROUP</p>
+  <h1 style="margin:0 0 8px 0;color:#1a1500;">30th Meeting</h1>
+  <p style="margin:0;font-size:18px;"><strong>AI Governance and Open Source Compliance in Finance</strong></p>
+  <p style="margin:12px 0 0 0;font-size:14px;opacity:.85;">2026.06.09 (Tue) 14:00-17:00 · KakaoBank</p>
+</div>
 
-- Date & Time: 2026-06-09 (Tue) 2:00 PM – 5:00 PM
-- Location: KakaoBank (Parc.1 Tower, 108 Yeoui-daero, Yeongdeungpo-gu, Seoul, Republic of Korea  - https://maps.app.goo.gl/kiA47oQHq3g2jkLd6 )
+<div style="margin:0 0 20px 0;display:flex;flex-wrap:wrap;gap:8px;">
+  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># OpenChain</span>
+  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># AI Governance</span>
+  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># Financial Audit</span>
+  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># OSS Compliance</span>
+</div>
+
+<div style="border:1px solid #f0d860;border-left:4px solid #ffb800;border-radius:10px;padding:12px 14px;background:#fffbeb;margin-bottom:20px;">
+This meeting focuses on <strong>open source governance in the AI era</strong> and <strong>audit readiness checkpoints for the financial sector</strong>,
+sharing practical cases that practitioners can apply immediately.
+</div>
+
+## Event Info
+
+| Item | Details |
+|---|---|
+| Date & Time | **2026-06-09 (Tue) 14:00 – 17:00** |
+| Venue | KakaoBank (Parc.1 Tower 2, 35F, Yeouido) |
+| Location | [Open in Google Maps](https://maps.app.goo.gl/kiA47oQHq3g2jkLd6) |
+| Keywords | `OpenChain` `AI` `Governance` `Finance` |
+
+## Program Highlights
+
+<div style="display:grid;gap:10px;margin-bottom:8px;">
+  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
+    <strong style="color:#8b6914;">Session 1</strong><br>
+    AI-driven Open Source Governance<br>
+    <span style="font-size:13px;color:#6b5a30;">Heonkwan Ha · KakaoBank</span>
+  </div>
+  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
+    <strong style="color:#8b6914;">Session 2</strong><br>
+    The Impact of Claude Mythos on Open Source<br>
+    <span style="font-size:13px;color:#6b5a30;">Kangbo Kim · AhnLab</span>
+  </div>
+  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
+    <strong style="color:#8b6914;">Session 3</strong><br>
+    Open Source Checklist Analysis for Financial Sector Audits<br>
+    <span style="font-size:13px;color:#6b5a30;">KakaoBank</span>
+  </div>
+</div>
+
+## Who Should Attend
+
+- Practitioners managing open source compliance policies in finance and regulated industries
+- Organizations redefining open source governance scope after AI adoption
+- Teams preparing checklists and evidence for audits and inspections
 
 ## Agenda
 
-| Time        | Agenda                                              | Speaker                          | Slide |
-|-------------|-----------------------------------------------------|----------------------------------|-------|
-| 14:00~14:10 | Welcome & Introduction                              | Steering Committee               | - |
-| 14:10~14:30 | OpenChain Updates                                   | Steering Committee               | - |
-| 14:30~14:55 | Session1: AI-driven Open Source Governance          | Heonkwan Ha, KakaoBank           | - |
-| 14:55~15:15 | Break & Networking                                  | -                                | - |
-| 15:15~15:40 | Session2: The Impact of Claude Mythos on Open Source | Kangbo Kim, AhnLab               | - |
-| 15:40~16:05 | Session3: Open Source Checklist Analysis for Financial Sector Audits | KakaoBank | - |
-| 16:05~16:50 | Group Discussion                                    | All                              | - |
-| 16:50~17:00 | Closing & Group Photo                               | Steering Committee               | - |
-
+<div style="display:grid;gap:10px;">
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
+    <div style="font-weight:800;color:#8b6914;">14:00-14:10</div>
+    <div><strong>Welcome & Introduction</strong><br><span style="font-size:13px;color:#6b5a30;">Steering Committee</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
+    <div style="font-weight:800;color:#8b6914;">14:10-14:30</div>
+    <div><strong>OpenChain Updates</strong><br><span style="font-size:13px;color:#6b5a30;">Steering Committee</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
+    <div style="font-weight:800;color:#8b6914;">14:30-14:55</div>
+    <div><strong>Session 1. AI-driven Open Source Governance</strong><br><span style="font-size:13px;color:#6b5a30;">Heonkwan Ha · KakaoBank</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px dashed #e8d880;border-radius:12px;padding:12px 14px;background:#fffef0;">
+    <div style="font-weight:800;color:#8b6914;">14:55-15:15</div>
+    <div><strong>Break & Networking</strong><br><span style="font-size:13px;color:#6b5a30;">Coffee break</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
+    <div style="font-weight:800;color:#8b6914;">15:15-15:40</div>
+    <div><strong>Session 2. The Impact of Claude Mythos on Open Source</strong><br><span style="font-size:13px;color:#6b5a30;">Kangbo Kim · AhnLab</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
+    <div style="font-weight:800;color:#8b6914;">15:40-16:05</div>
+    <div><strong>Session 3. Open Source Checklist Analysis for Financial Sector Audits</strong><br><span style="font-size:13px;color:#6b5a30;">KakaoBank</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
+    <div style="font-weight:800;color:#8b6914;">16:05-16:50</div>
+    <div><strong>Group Discussion</strong><br><span style="font-size:13px;color:#6b5a30;">All Participants</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
+    <div style="font-weight:800;color:#8b6914;">16:50-17:00</div>
+    <div><strong>Closing & Group Photo</strong><br><span style="font-size:13px;color:#6b5a30;">Steering Committee</span></div>
+  </div>
+</div>
 
 ## Sponsor
 
-![](../../../../images/content/about/logo/kakaobank.png)
-
+<div style="text-align:center;padding:16px 12px;border:1px solid #f0d860;border-radius:12px;background:linear-gradient(180deg,#fffef5 0%,#fff9db 100%);">
+  <img src="../../../../images/content/about/logo/kakaobank.png" alt="KakaoBank" style="max-width:220px;width:100%;height:auto;">
+</div>

--- a/content/en/meeting/2026/_index.md
+++ b/content/en/meeting/2026/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2026"
 linkTitle: "2026"
-weight: 2026
+weight: 7974
 type: docs
 description: >
   OpenChain KWG meetings held in 2026 (29th ~ 30th)

--- a/content/ko/meeting/2019/_index.md
+++ b/content/ko/meeting/2019/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2019"
 linkTitle: "2019"
-weight: 2019
+weight: 7981
 type: docs
 description: >
   2019년에 개최된 OpenChain KWG 미팅 (1st ~ 4th)

--- a/content/ko/meeting/2020/_index.md
+++ b/content/ko/meeting/2020/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2020"
 linkTitle: "2020"
-weight: 2020
+weight: 7980
 type: docs
 description: >
   2020년에 개최된 OpenChain KWG 미팅 (5th ~ 8th)

--- a/content/ko/meeting/2021/_index.md
+++ b/content/ko/meeting/2021/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2021"
 linkTitle: "2021"
-weight: 2021
+weight: 7979
 type: docs
 description: >
   2021년에 개최된 OpenChain KWG 미팅 (9th ~ 12nd)

--- a/content/ko/meeting/2022/_index.md
+++ b/content/ko/meeting/2022/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2022"
 linkTitle: "2022"
-weight: 2022
+weight: 7978
 type: docs
 description: >
   2022년에 개최된 OpenChain KWG 미팅 (13th ~ 16th)

--- a/content/ko/meeting/2023/_index.md
+++ b/content/ko/meeting/2023/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2023"
 linkTitle: "2023"
-weight: 2023
+weight: 7977
 type: docs
 description: >
   2023년에 개최된 OpenChain KWG 미팅 (17th ~ 20th)

--- a/content/ko/meeting/2024/_index.md
+++ b/content/ko/meeting/2024/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2024"
 linkTitle: "2024"
-weight: 2024
+weight: 7976
 type: docs
 description: >
   2024년에 개최된 OpenChain KWG 미팅 (21st ~ 24th)

--- a/content/ko/meeting/2025/_index.md
+++ b/content/ko/meeting/2025/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2025"
 linkTitle: "2025"
-weight: 2025
+weight: 7975
 type: docs
 description: >
   2025년에 개최된 OpenChain KWG 미팅 (25th ~ 28th)

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -10,26 +10,99 @@ aliases:
   - /meeting/30th/
 ---
 
-## 일정
+<div style="padding:26px;border-radius:18px;background:linear-gradient(135deg,#ffe812 0%,#ffd400 45%,#ffb800 100%);color:#1a1500;margin-bottom:14px;box-shadow:0 12px 28px rgba(255,184,0,.35);">
+  <p style="margin:0 0 8px 0;letter-spacing:.08em;font-size:12px;font-weight:700;opacity:.75;">OPENCHAIN KOREA WORK GROUP</p>
+  <h1 style="margin:0 0 8px 0;color:#1a1500;">30th Meeting</h1>
+  <p style="margin:0;font-size:18px;"><strong>AI 거버넌스와 금융권 오픈소스 컴플라이언스</strong></p>
+  <p style="margin:12px 0 0 0;font-size:14px;opacity:.85;">2026.06.09 (화) 14:00-17:00 · 카카오뱅크</p>
+</div>
 
-* 일정: 2026-06-09 (화) 오후 2시~5시
-* 장소: 카카오뱅크 (여의도 파크원 타워2 35층 - https://maps.app.goo.gl/kiA47oQHq3g2jkLd6 )
+<div style="margin:0 0 20px 0;display:flex;flex-wrap:wrap;gap:8px;">
+  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># OpenChain</span>
+  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># AI Governance</span>
+  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># 금융권 Audit</span>
+  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># OSS Compliance</span>
+</div>
+
+<div style="border:1px solid #f0d860;border-left:4px solid #ffb800;border-radius:10px;padding:12px 14px;background:#fffbeb;margin-bottom:20px;">
+이번 미팅은 <strong>AI 시대의 오픈소스 거버넌스 실무</strong>와 <strong>금융권 감사 대응 체크포인트</strong>를 중심으로,
+현업 담당자들이 바로 적용할 수 있는 사례를 공유합니다.
+</div>
+
+## 행사 정보
+
+| 항목 | 내용 |
+|---|---|
+| 일시 | **2026-06-09 (화) 14:00 ~ 17:00** |
+| 장소 | 카카오뱅크 (여의도 파크원 타워2 35층) |
+| 위치 | [Google Maps 바로가기](https://maps.app.goo.gl/kiA47oQHq3g2jkLd6) |
+| 키워드 | `OpenChain` `AI` `Governance` `금융` |
+
+## 프로그램 하이라이트
+
+<div style="display:grid;gap:10px;margin-bottom:8px;">
+  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
+    <strong style="color:#8b6914;">Session 1</strong><br>
+    AI-driven Open Source Governance<br>
+    <span style="font-size:13px;color:#6b5a30;">하헌관 · 카카오뱅크</span>
+  </div>
+  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
+    <strong style="color:#8b6914;">Session 2</strong><br>
+    Claude Mythos가 Open Source에 미치는 영향<br>
+    <span style="font-size:13px;color:#6b5a30;">김강보 · 안랩</span>
+  </div>
+  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
+    <strong style="color:#8b6914;">Session 3</strong><br>
+    금융권 감사 대비 오픈소스 체크리스트 분석<br>
+    <span style="font-size:13px;color:#6b5a30;">카카오뱅크</span>
+  </div>
+</div>
+
+## 이런 분께 추천
+
+- 금융/규제 산업에서 오픈소스 컴플라이언스 정책을 운영하는 담당자
+- AI 도입 이후 오픈소스 거버넌스 범위를 재정의해야 하는 조직
+- 감사/점검 대응을 위한 체크리스트와 증적 관리가 필요한 팀
 
 ## 아젠다
 
-| Time        | Agenda                                              | Speaker                          | Slide |
-|-------------|-----------------------------------------------------|----------------------------------|-------|
-| 14:00~14:10 | 인사 및 참석자 소개                                  | 운영진                           | - |
-| 14:10~14:30 | OpenChain Updates                                   | 운영진                           | - |
-| 14:30~14:55 | Session1: AI-driven Open Source Governance           | 하헌관, 카카오뱅크                | - |
-| 14:55~15:15 | 휴식 및 네트워킹                                     | -                                | - |
-| 15:15~15:40 | Session2: Claude Mythos가 Open Source에 미치는 영향   | 김강보, 안랩                     | - |
-| 15:40~16:05 | Session3: 금융권 감사 대비 오픈소스 체크리스트 분석     | 카카오뱅크                       | - |
-| 16:05~16:50 | 그룹 토의                                            | All                              | - |
-| 16:50~17:00 | 마무리 및 단체 사진 촬영                              | 운영진                           | - |
-
+<div style="display:grid;gap:10px;">
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
+    <div style="font-weight:800;color:#8b6914;">14:00-14:10</div>
+    <div><strong>인사 및 참석자 소개</strong><br><span style="font-size:13px;color:#6b5a30;">운영진</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
+    <div style="font-weight:800;color:#8b6914;">14:10-14:30</div>
+    <div><strong>OpenChain Updates</strong><br><span style="font-size:13px;color:#6b5a30;">운영진</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
+    <div style="font-weight:800;color:#8b6914;">14:30-14:55</div>
+    <div><strong>Session 1. AI-driven Open Source Governance</strong><br><span style="font-size:13px;color:#6b5a30;">하헌관 · 카카오뱅크</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px dashed #e8d880;border-radius:12px;padding:12px 14px;background:#fffef0;">
+    <div style="font-weight:800;color:#8b6914;">14:55-15:15</div>
+    <div><strong>휴식 및 네트워킹</strong><br><span style="font-size:13px;color:#6b5a30;">Coffee break</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
+    <div style="font-weight:800;color:#8b6914;">15:15-15:40</div>
+    <div><strong>Session 2. Claude Mythos가 Open Source에 미치는 영향</strong><br><span style="font-size:13px;color:#6b5a30;">김강보 · 안랩</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
+    <div style="font-weight:800;color:#8b6914;">15:40-16:05</div>
+    <div><strong>Session 3. 금융권 감사 대비 오픈소스 체크리스트 분석</strong><br><span style="font-size:13px;color:#6b5a30;">카카오뱅크</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
+    <div style="font-weight:800;color:#8b6914;">16:05-16:50</div>
+    <div><strong>그룹 토의</strong><br><span style="font-size:13px;color:#6b5a30;">All Participants</span></div>
+  </div>
+  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
+    <div style="font-weight:800;color:#8b6914;">16:50-17:00</div>
+    <div><strong>마무리 및 단체 사진 촬영</strong><br><span style="font-size:13px;color:#6b5a30;">운영진</span></div>
+  </div>
+</div>
 
 ## Sponsor
 
-![](../../../images/content/about/logo/kakaobank.png)
-
+<div style="text-align:center;padding:16px 12px;border:1px solid #f0d860;border-radius:12px;background:linear-gradient(180deg,#fffef5 0%,#fff9db 100%);">
+  <img src="../../../images/content/about/logo/kakaobank.png" alt="KakaoBank" style="max-width:220px;width:100%;height:auto;">
+</div>

--- a/content/ko/meeting/2026/_index.md
+++ b/content/ko/meeting/2026/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "2026"
 linkTitle: "2026"
-weight: 2026
+weight: 7974
 type: docs
 description: >
   2026년에 개최된 OpenChain KWG 미팅 (29th ~ 30th)


### PR DESCRIPTION
## Summary
- Redesign the 30th meeting pages in both Korean and English with a conference-style layout
- Apply a KakaoBank-inspired yellow visual theme to hero, highlight cards, agenda timeline cards, and sponsor section
- Keep existing meeting content while improving readability and presentation structure

## Test plan
- [x] Run local Hugo build (`npm run _hugo-dev -- --minify`)
- [x] Verify KO page renders at `/meeting/2026/30th/`
- [x] Verify EN page renders at `/en/meeting/2026/30th/`

Made with [Cursor](https://cursor.com)