### PR TITLE
docs(meeting): 30th Session3 발표 주제·발표자 변경

### DIFF
--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -53,8 +53,8 @@ sharing practical cases that practitioners can apply immediately.
   </div>
   <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
     <strong style="color:#8b6914;">Session 3</strong><br>
-    Open Source Checklist Analysis for Financial Sector Audits<br>
-    <span style="font-size:13px;color:#6b5a30;">KakaoBank</span>
+    Experience Report on Open Source Operations as a Financial Company<br>
+    <span style="font-size:13px;color:#6b5a30;">Minae Lee · KakaoBank</span>
   </div>
 </div>
 
@@ -89,7 +89,7 @@ sharing practical cases that practitioners can apply immediately.
   </div>
   <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
     <div style="font-weight:800;color:#8b6914;">15:40-16:05</div>
-    <div><strong>Session 3. Open Source Checklist Analysis for Financial Sector Audits</strong><br><span style="font-size:13px;color:#6b5a30;">KakaoBank</span></div>
+    <div><strong>Session 3. Experience Report on Open Source Operations as a Financial Company</strong><br><span style="font-size:13px;color:#6b5a30;">Minae Lee · KakaoBank</span></div>
   </div>
   <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
     <div style="font-weight:800;color:#8b6914;">16:05-16:50</div>

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -53,8 +53,8 @@ aliases:
   </div>
   <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
     <strong style="color:#8b6914;">Session 3</strong><br>
-    금융권 감사 대비 오픈소스 체크리스트 분석<br>
-    <span style="font-size:13px;color:#6b5a30;">카카오뱅크</span>
+    금융회사로서의 오픈소스 관련 업무 대응 후기<br>
+    <span style="font-size:13px;color:#6b5a30;">이민애 · 카카오뱅크</span>
   </div>
 </div>
 
@@ -89,7 +89,7 @@ aliases:
   </div>
   <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
     <div style="font-weight:800;color:#8b6914;">15:40-16:05</div>
-    <div><strong>Session 3. 금융권 감사 대비 오픈소스 체크리스트 분석</strong><br><span style="font-size:13px;color:#6b5a30;">카카오뱅크</span></div>
+    <div><strong>Session 3. 금융회사로서의 오픈소스 관련 업무 대응 후기</strong><br><span style="font-size:13px;color:#6b5a30;">이민애 · 카카오뱅크</span></div>
   </div>
   <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
     <div style="font-weight:800;color:#8b6914;">16:05-16:50</div>


### PR DESCRIPTION
## Summary

- Session3 발표 주제 변경: `금융권 감사 대비 오픈소스 체크리스트 분석` → `금융회사로서의 오픈소스 관련 업무 대응 후기`
- Session3 발표자 명시: `카카오뱅크` → `이민애 · 카카오뱅크`
- Program Highlights 카드 + Agenda 카드 두 영역 갱신, ko/en 동기화

## Test plan

- [ ] `hugo server -D` 로컬 프리뷰에서 ko/en 30th 페이지 렌더링 확인
- [ ] Program Highlights·Agenda 두 카드 모두 새 주제·발표자로 표시되는지 확인