### PR TITLE
디자인 전면 개편 — Gemini/AI Studio 미감 (Phase 1~4)

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,0 +1,10 @@
+/*
+  OpenChain-KWG 커스텀 스타일 — main.scss 맨 끝에서 로드된다.
+  Phase 1: 다크 모드 색 대비 보정 import(opt-in).
+  네비바/사이드바/카드/히어로 등 시각 규칙은 이후 Phase에서 이 파일에 추가한다.
+*/
+
+// Docsy 다크 모드 보정(EXPERIMENTAL) — $enable-dark-mode 가 true일 때만 효과.
+@import 'td/color-adjustments-dark';
+@import 'td/code-dark';
+@import 'td/gcs-search-dark';

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,22 +1,141 @@
 /*
   OpenChain-KWG 커스텀 스타일 — main.scss 맨 끝에서 로드된다.
-  Phase 1: 다크 모드 색 대비 보정 import(opt-in).
-  네비바/사이드바/카드/히어로 등 시각 규칙은 이후 Phase에서 이 파일에 추가한다.
+  Phase 1: 다크 보정 import. Phase 2: 제목 자간. Phase 3: Gemini 정렬(네비바·조판·검색·TOC 등).
 */
 
-// Docsy 다크 모드 보정(EXPERIMENTAL) — $enable-dark-mode 가 true일 때만 효과.
+// ── Docsy 다크 모드 보정(EXPERIMENTAL) — $enable-dark-mode 가 true일 때만 효과 ──
 @import 'td/color-adjustments-dark';
 @import 'td/code-dark';
 @import 'td/gcs-search-dark';
 
-// ── 타이포 위계: Inter에 맞춘 또렷한 제목(Gemini/AI Studio 풍) ──
-// Inter는 큰 글자에서 살짝 좁은 자간이 깔끔하다.
+// ── 본문 조판: Gemini식 여유로운 가독성 + 제목 크기/굵기 정상화 ──
+// Inter는 Google Sans보다 묵직해 보이므로 제목 크기를 Gemini 수준으로 낮춘다.
 .td-content {
-  h1 { font-weight: 700; letter-spacing: -0.022em; }
-  h2,
-  h3 { font-weight: 600; letter-spacing: -0.018em; }
+  line-height: 1.7;
+
+  p,
+  li { line-height: 1.7; }
+  > p { margin-bottom: 1.1rem; }
+
+  // Google devsite 표준 px(16px base): h1 28 / h2 22 / h3 16 / h4 14
+  h1 { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
+  h2 {
+    font-size: 1.375rem;
+    font-weight: 500;
+    letter-spacing: -0.018em;
+    margin-top: 2.5rem;
+  }
+  h3 {
+    font-size: 1rem;
+    font-weight: 500;
+    letter-spacing: -0.012em;
+    margin-top: 2rem;
+  }
   h4,
-  h5 { font-weight: 600; letter-spacing: -0.012em; }
+  h5 { font-size: 0.875rem; font-weight: 500; letter-spacing: -0.008em; }
 }
-.td-navbar .navbar-brand,
-.td-navbar .navbar-brand__name { font-weight: 600; letter-spacing: -0.01em; }
+
+.td-content > h1:first-child,
+h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
+
+// 네비바 텍스트 — Gemini 상단 메뉴는 14px. 브랜드만 약간 키움
+.td-navbar {
+  .navbar-brand__name { font-size: 1.125rem; font-weight: 500; letter-spacing: -0.01em; }
+  // Roboto는 x-height가 작아 14px가 작아 보임 → 15px로 보정(Gemini 체감 크기)
+  .nav-link { font-size: 0.9375rem; font-weight: 400; }
+}
+
+// ── 네비바: 화이트 반투명 + 얇은 보더(홈 cover 위는 기존 투명 유지) ──
+.td-navbar:not(.td-navbar-cover) {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: none;
+
+  .nav-link.active { color: $primary; font-weight: 500; }
+}
+[data-bs-theme="dark"] .td-navbar:not(.td-navbar-cover) {
+  background: rgba(20, 22, 24, 0.85);
+  border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+// ── 검색: Gemini식 둥근 연회색 박스 ──
+.td-search__input {
+  border-radius: 2rem;
+  border: 1px solid var(--bs-border-color);
+  background-color: var(--bs-tertiary-bg);
+  padding-left: 2.4rem;
+}
+.td-search__input:focus {
+  background-color: var(--bs-body-bg);
+  box-shadow: 0 0 0 3px rgba($primary, 0.15);
+}
+
+// ── 우측 TOC: Gemini 14px + active는 색만(굵기 키우지 않음) ──
+.td-sidebar-toc {
+  font-size: 0.875rem;
+
+  .td-toc {
+    a {
+      border-left: 2px solid transparent;
+      padding-left: 0.75rem;
+      font-weight: 400;
+    }
+    a:hover { color: $primary; }
+    li.active > a,
+    a.active {
+      color: $primary;
+      background: none;
+      border-left-color: $primary;
+      font-weight: 500;
+    }
+  }
+}
+
+// ── 좌측 사이드바: Roboto 보정 15px + 굵기 정상화(항목 regular, 그룹헤더만 medium) ──
+.td-sidebar-nav {
+  font-size: 0.9375rem;
+
+  .td-sidebar-nav__section-title {
+    font-weight: 500;
+    font-size: 0.9375rem;
+    letter-spacing: -0.01em;
+    margin-top: 0.4rem;
+  }
+  .td-sidebar-link {
+    padding-top: 0.18rem;
+    padding-bottom: 0.18rem;
+    font-weight: 400;
+  }
+  .td-sidebar-nav-active-item { color: $primary; font-weight: 500; }
+}
+
+// ── 본문 상단 Tags/Categories 배지: 화살표(clip-path) 제거 → 둥근 pill ──
+.taxonomy-term {
+  -webkit-clip-path: none;
+  clip-path: none;
+  border-radius: 1rem;
+  padding: 0.05rem 0.65rem;
+}
+
+// ── 우측 편집 액션(페이지 보기/편집/이슈 생성/프린트) 숨김 — Gemini식 미니멀 ──
+.td-page-meta { display: none; }
+
+// ── 우측 Tag Cloud 숨김 ──
+// Docsy는 taxonomyCloud=[] 를 falsy로 보고 오히려 전체 taxonomy를 렌더하고,
+// 빈 partial 오버라이드도 폴백되는 경우가 있어 SCSS로 확실히 숨긴다.
+// (본문 상단 Tags 배지 .taxonomy-terms-article 는 유지)
+.td-sidebar-toc .taxonomy-terms-cloud { display: none; }
+
+// ── 섹션 인덱스(하위 페이지 목록) 카드 제목 ──
+// Docsy는 항목 제목을 .section-index .entry h5 로 출력하는데, 본문 h5 축소(14px)의
+// 영향을 받아 작아지므로 카드 제목용 크기(18px)를 별도로 지정한다.
+.section-index .entry {
+  h5 {
+    font-size: 1.125rem;
+    margin-bottom: 0.25rem;
+
+    a { font-weight: 500; }
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -8,3 +8,15 @@
 @import 'td/color-adjustments-dark';
 @import 'td/code-dark';
 @import 'td/gcs-search-dark';
+
+// ── 타이포 위계: Inter에 맞춘 또렷한 제목(Gemini/AI Studio 풍) ──
+// Inter는 큰 글자에서 살짝 좁은 자간이 깔끔하다.
+.td-content {
+  h1 { font-weight: 700; letter-spacing: -0.022em; }
+  h2,
+  h3 { font-weight: 600; letter-spacing: -0.018em; }
+  h4,
+  h5 { font-weight: 600; letter-spacing: -0.012em; }
+}
+.td-navbar .navbar-brand,
+.td-navbar .navbar-brand__name { font-weight: 600; letter-spacing: -0.01em; }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -139,3 +139,342 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
     a { font-weight: 500; }
   }
 }
+
+// ── 홈 랜딩 (layouts/index.html) — ai.google.dev풍 ──────────────
+.kwg-home { overflow-x: hidden; }
+// 홈 body 자체를 다크로 — 100vw 히어로의 좌우 가장자리에 흰 배경이 비치지 않게
+.td-home { background-color: #060b11; }
+// Docsy .td-outer(container-fluid + td-block-padding)의 좌우 패딩 제거 → 콘텐츠가 진짜 풀폭
+.td-home .td-outer {
+  padding-left: 0;
+  padding-right: 0;
+  max-width: none;
+}
+// 본문 콘텐츠 폭(블록·카드를 적당한 폭으로 가운데). 히어로만 100vw 풀폭
+.kwg-home .container { max-width: 1280px; }
+
+// 히어로: 단체사진 배경 + 다크 그라데이션 오버레이(배경은 layouts inline style)
+.kwg-hero {
+  position: relative;
+  // Docsy 컨테이너 패딩을 벗어나 뷰포트 풀폭으로(배경이 좌우 끝까지)
+  width: 100vw;
+  left: 50%;
+  margin-left: -50vw;
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  padding: 9.5rem 0 5rem;
+  text-align: center;
+  background-color: #06141b;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  overflow: hidden;
+}
+.kwg-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(55% 45% at 50% 8%, rgba(2, 171, 184, 0.2), transparent 60%);
+  z-index: 0;
+  pointer-events: none;
+}
+.kwg-hero__inner { position: relative; z-index: 1; width: 100%; }
+.kwg-hero__badge {
+  display: inline-block;
+  padding: 0.45rem 1.1rem;
+  margin-bottom: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 2rem;
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(8px);
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: rgba(255, 255, 255, 0.82);
+}
+.kwg-hero__title {
+  font-size: 4.25rem;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 1.04;
+  margin-bottom: 1.5rem;
+  background: linear-gradient(120deg, #ffffff 35%, #9fecf3 70%, #c3b1f7);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+.kwg-hero__sub {
+  font-size: 1.3rem;
+  color: rgba(255, 255, 255, 0.75);
+  max-width: 620px;
+  margin: 0 auto 2.5rem;
+  line-height: 1.6;
+}
+.kwg-hero__cta { display: flex; gap: 0.85rem; justify-content: center; flex-wrap: wrap; }
+.kwg-hero__cta .btn-primary {
+  border-radius: 2rem;
+  padding: 0.75rem 1.7rem;
+  font-weight: 500;
+  background: linear-gradient(135deg, $primary, $secondary);
+  border: none;
+  box-shadow: 0 8px 24px rgba(2, 171, 184, 0.3);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.kwg-hero__cta .btn-primary:hover {
+  box-shadow: 0 10px 30px rgba(2, 171, 184, 0.45);
+  transform: translateY(-1px);
+}
+.kwg-hero__cta .btn-outline-primary {
+  border-radius: 2rem;
+  padding: 0.75rem 1.7rem;
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(8px);
+}
+.kwg-hero__cta .btn-outline-primary:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: #fff;
+  color: #fff;
+}
+
+// 홈 네비바: 투명 위 흰 글씨(스크롤 시 Docsy navbar-bg-onscroll 가 솔리드 처리)
+.td-home .td-navbar.td-navbar-cover {
+  background: transparent;
+  box-shadow: none;
+}
+
+// 섹션 — 넉넉한 여백(ai.google.dev식 시원함)
+.kwg-section { padding: 6.5rem 0; }
+.kwg-section--alt { background: var(--bs-tertiary-bg); }
+.kwg-section__title {
+  font-size: 2.4rem;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  text-align: center;
+  margin-bottom: 0.75rem;
+}
+.kwg-section__lead {
+  text-align: center;
+  font-size: 1.1rem;
+  color: var(--bs-secondary-color);
+  margin-bottom: 3.5rem;
+}
+
+// 큰 컨테이너 블록 (ai.google.dev식 섹션 카드: 피처 + 서브카드를 함께 감쌈)
+// 가이드 탭 패널(max-width 1140)과 폭을 맞춘다
+.kwg-block {
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 3rem 3.25rem;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    radial-gradient(100% 100% at 100% 0%, rgba(2, 171, 184, 0.07), transparent 55%),
+    linear-gradient(160deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.008));
+  overflow: hidden;
+}
+
+// 피처(상단): 좌측 텍스트 + 우측 추상 glow 비주얼. 블록은 풀폭이라 내부 콘텐츠만 가운데로 모음
+.kwg-feature {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 2.5rem;
+  align-items: center;
+  max-width: 1140px;
+  margin: 0 auto 2.5rem;
+}
+.kwg-feature__title {
+  font-size: 2.1rem;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: #fff;
+  margin-bottom: 1.1rem;
+}
+.kwg-feature__desc {
+  font-size: 1.02rem;
+  color: rgba(255, 255, 255, 0.62);
+  line-height: 1.7;
+  margin-bottom: 1.75rem;
+  max-width: 460px;
+}
+.kwg-btn-pill {
+  display: inline-block;
+  padding: 0.7rem 1.6rem;
+  border-radius: 2rem;
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: #fff;
+  text-decoration: none;
+  background: linear-gradient(135deg, $primary, $secondary);
+  box-shadow: 0 8px 24px rgba(2, 171, 184, 0.3);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.kwg-btn-pill:hover {
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(2, 171, 184, 0.45);
+}
+
+// 피처 우측 비주얼 컨테이너 (SVG art img를 담는다)
+.kwg-feature__visual {
+  position: relative;
+  min-height: 280px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.kwg-feature__visual .kwg-tabs__art { max-width: 360px; }
+
+// 가이드 탭 (순수 CSS radio, 세그먼트 컨트롤 스타일)
+.kwg-tabs { position: relative; text-align: center; }
+.kwg-tabs__radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+// 탭바: 하나의 둥근 묶음 안에서 선택된 탭이 채워짐 → '탭' 인지가 명확
+.kwg-tabs__nav {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.35rem;
+  margin-bottom: 1.75rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 2rem;
+}
+.kwg-tabs__nav label {
+  padding: 0.55rem 1.3rem;
+  border-radius: 2rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.55);
+  white-space: nowrap;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.kwg-tabs__nav label:hover { color: #fff; }
+.kwg-tabs__panel {
+  display: none;
+  grid-template-columns: 1fr 1fr;
+  gap: 3rem;
+  align-items: center;
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 3rem 3.25rem;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    radial-gradient(100% 100% at 100% 0%, rgba(2, 171, 184, 0.07), transparent 55%),
+    linear-gradient(160deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.008));
+  text-decoration: none;
+  text-align: left;
+}
+.kwg-tabs__panel .kwg-btn-pill { align-self: flex-start; }
+.kwg-tabs__visual {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 170px;
+}
+.kwg-tabs__art {
+  width: 100%;
+  max-width: 320px;
+  height: auto;
+  display: block;
+}
+#gt-1:checked ~ .kwg-tabs__nav label[for="gt-1"],
+#gt-2:checked ~ .kwg-tabs__nav label[for="gt-2"],
+#gt-3:checked ~ .kwg-tabs__nav label[for="gt-3"],
+#gt-4:checked ~ .kwg-tabs__nav label[for="gt-4"] {
+  color: #fff;
+  background: linear-gradient(135deg, $primary, $secondary);
+}
+#gt-1:checked ~ #gp-1,
+#gt-2:checked ~ #gp-2,
+#gt-3:checked ~ #gp-3,
+#gt-4:checked ~ #gp-4 { display: grid; }
+
+// 서브카드(하단): 아이콘 박스 + 텍스트 + pill 링크 (가로형, ai.google.dev식)
+.kwg-subcard-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  max-width: 1140px;
+  margin: 0 auto;
+}
+.kwg-subcard-grid--3 { grid-template-columns: repeat(3, 1fr); }
+.kwg-subcard {
+  display: flex;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  text-decoration: none;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+.kwg-subcard:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(2, 171, 184, 0.4);
+  transform: translateY(-2px);
+}
+.kwg-subcard__body { display: flex; flex-direction: column; min-width: 0; }
+.kwg-subcard__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 0.35rem;
+}
+.kwg-subcard__desc {
+  font-size: 0.88rem;
+  color: rgba(255, 255, 255, 0.6);
+  line-height: 1.55;
+  margin-bottom: 0.85rem;
+  flex-grow: 1;
+}
+.kwg-subcard__link {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 2rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.85);
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+.kwg-subcard:hover .kwg-subcard__link {
+  background: rgba(2, 171, 184, 0.18);
+  border-color: rgba(2, 171, 184, 0.4);
+}
+
+// ── 홈 다크 테마 통일 (ai.google.dev풍) — 라이트 규칙 위에 덮어쓴다 ──
+.kwg-home {
+  background: #060b11;
+  color: rgba(255, 255, 255, 0.85);
+
+  .kwg-section--alt { background: rgba(255, 255, 255, 0.03); }
+  .kwg-section__title { color: #fff; }
+  .kwg-section__lead { color: rgba(255, 255, 255, 0.55); }
+}
+
+@media (max-width: 768px) {
+  .kwg-hero { padding: 7rem 0 3.5rem; }
+  .kwg-hero__title { font-size: 2.4rem; }
+  .kwg-block { padding: 1.75rem; }
+  .kwg-feature { grid-template-columns: 1fr; }
+  .kwg-feature__visual { min-height: 220px; }
+  .kwg-feature__title { font-size: 1.7rem; }
+  #gt-1:checked ~ #gp-1,
+  #gt-2:checked ~ #gp-2,
+  #gt-3:checked ~ #gp-3,
+  #gt-4:checked ~ #gp-4 { grid-template-columns: 1fr; padding: 2rem; }
+  .kwg-subcard-grid { grid-template-columns: 1fr; }
+}

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -18,10 +18,9 @@ $link-hover-decoration: none !default;
 // 웹폰트 로딩은 layouts/_partials/hooks/head-end.html 에서 수행한다.
 // Inter를 앞에 두어 영문·숫자는 Inter, 한글은 Pretendard로 폴백된다.
 // _variables_forward.scss 기본값을 덮어쓰려면 !default 를 붙이지 않는다.
-$td-fonts-serif: "Inter", "Pretendard Variable", Pretendard, -apple-system,
-  BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", "Noto Sans KR",
-  Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
-  "Segoe UI Emoji", "Segoe UI Symbol";
+$td-fonts-serif: "Roboto", "Pretendard Variable", Pretendard, -apple-system,
+  BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", "Helvetica Neue",
+  Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $td-font-family-monospace: "JetBrains Mono", SFMono-Regular, Menlo, Monaco,
   Consolas, "Liberation Mono", "Courier New", monospace;
 
@@ -42,3 +41,7 @@ $enable-shadows: true;
 $box-shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1);
 $box-shadow: 0 2px 8px rgba(16, 24, 40, 0.08), 0 4px 16px rgba(16, 24, 40, 0.06);
 $box-shadow-lg: 0 8px 24px rgba(16, 24, 40, 0.1), 0 12px 40px rgba(16, 24, 40, 0.08);
+
+// ── 본문 글자색: 순검정 대신 부드러운 진회색(Gemini식 가독성) ──
+// 다크 모드 글자색은 Bootstrap/Docsy 다크 보정이 자동 처리한다.
+$body-color: #2b2f33;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -14,6 +14,23 @@ $link-decoration: none !default;
 $link-hover-color: darken($link-color, 15%) !default;
 $link-hover-decoration: none !default;
 
+// ── 타이포그래피: 영문 Inter + 한글 Pretendard ──────────────
+// 웹폰트 로딩은 layouts/_partials/hooks/head-end.html 에서 수행한다.
+// Inter를 앞에 두어 영문·숫자는 Inter, 한글은 Pretendard로 폴백된다.
+// _variables_forward.scss 기본값을 덮어쓰려면 !default 를 붙이지 않는다.
+$td-fonts-serif: "Inter", "Pretendard Variable", Pretendard, -apple-system,
+  BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", "Noto Sans KR",
+  Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
+  "Segoe UI Emoji", "Segoe UI Symbol";
+$td-font-family-monospace: "JetBrains Mono", SFMono-Regular, Menlo, Monaco,
+  Consolas, "Liberation Mono", "Courier New", monospace;
+
+// Docsy는 $td-enable-google-fonts=true 일 때만 위 스택을 Bootstrap 본문 폰트에
+// 연결한다. Open Sans 자동 로드를 피하려고 google-fonts를 끈 상태이므로,
+// Bootstrap 폰트 변수에 직접 연결한다(_variables.scss 이전 단계라 안전).
+$font-family-sans-serif: $td-fonts-serif;
+$font-family-monospace: $td-font-family-monospace;
+
 // ── 형태: Gemini/AI Studio식 둥근 모서리 ─────────────────────
 $border-radius: 0.75rem;
 $border-radius-sm: 0.5rem;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1,13 +1,27 @@
 /*
-
-Add styles or override variables from the theme here.
-
+  OpenChain-KWG 디자인 토큰 — Bootstrap import 이전 단계.
+  Docsy/Bootstrap 표준 변수만 오버라이드한다(업그레이드 안전 등급).
+  실제 CSS 규칙은 _styles_project.scss, 다크 게이트는 _variables_project_after_bs.scss 참고.
 */
 
+// ── 브랜드 색 ───────────────────────────────────────────────
 $primary: #01819a;
 $secondary: #02abb8;
 
+// 링크
 $link-color: darken($secondary, 5%) !default;
 $link-decoration: none !default;
 $link-hover-color: darken($link-color, 15%) !default;
 $link-hover-decoration: none !default;
+
+// ── 형태: Gemini/AI Studio식 둥근 모서리 ─────────────────────
+$border-radius: 0.75rem;
+$border-radius-sm: 0.5rem;
+$border-radius-lg: 1rem;
+$border-radius-xl: 1.5rem;
+
+// ── 그림자: 얕고 부드럽게(중첩 레이어) ───────────────────────
+$enable-shadows: true;
+$box-shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1);
+$box-shadow: 0 2px 8px rgba(16, 24, 40, 0.08), 0 4px 16px rgba(16, 24, 40, 0.06);
+$box-shadow-lg: 0 8px 24px rgba(16, 24, 40, 0.1), 0 12px 40px rgba(16, 24, 40, 0.08);

--- a/assets/scss/_variables_project_after_bs.scss
+++ b/assets/scss/_variables_project_after_bs.scss
@@ -1,0 +1,13 @@
+/*
+  OpenChain-KWG — Bootstrap import 이후 단계.
+  다크 모드 게이트와 다크 변형 색 보정 변수를 정의한다.
+  Docsy td/* 보정 파일은 _styles_project.scss에서 import한다.
+*/
+
+// 다크 모드 활성화. Docsy의 td/_color-adjustments-dark, td/_code-dark,
+// td/_gcs-search-dark 가 이 변수를 @if 가드로 사용한다.
+$enable-dark-mode: true;
+
+// primary(#01819a)가 어두운 teal이라 22% 기본값으로는 다크 배경 대비가 부족하다.
+// 다크 변형 색의 lighten 폭을 상향(Phase 1에서 잠정값, 실측 후 조정 가능).
+$lighten-amount-for-dark-color-variant: 30%;

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -2,65 +2,7 @@
 title: OpenChain KWG
 ---
 
-{{< blocks/cover title="OpenChain Korea Work Group" image_anchor="top" height="full" >}}
-<a class="btn btn-lg btn-primary me-3 mb-4" href="/OpenChain-KWG/about/">
-  About <i class="fas fa-arrow-alt-circle-right ms-2"></i>
-</a>
-<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/OpenChain-Project/OpenChain-KWG">
-  GitHub <i class="fab fa-github ms-2 "></i>
-</a>
-<p class="lead mt-5">OpenChain KWG is a subgroup of the Linux Foundation OpenChain Project.</p>
-{{< blocks/link-down color="info" >}}
-{{< /blocks/cover >}}
-
-
-{{% blocks/lead color="info" %}}
-OpenChain KWG(Korea Work Group) is a group to create and share how to effectively achieve open source compliance for everyone through collaboration and sharing, the spirit of open source software!
-{{% /blocks/lead %}}
-
-
-{{% blocks/section color="primary" type="row" %}}
-{{% blocks/feature icon="fa-lightbulb" title="Join the Mailing List!" url="/OpenChain-KWG/about/subscribe"  %}}
-Anyone in charge of open source compliance at a Korean company that develops and distributes software can participate.
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fab fa-discord" title="Conllaborate on Discord!" url="https://discord.com/channels/1177116701561729104/" %}}
-With channels in Discord, you and your team know where to go to ask questions, share updates and stay in the loop.
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/OpenChain-Project/OpenChain-KWG" %}}
-Our activities are public on GitHub and all forms of contributions are welcome! Please create a [Pull Request](https://github.com/OpenChain-Project/OpenChain-KWG/pulls).
-{{% /blocks/feature %}}
-
-{{% /blocks/section %}}
-
-
-<!-- {{% blocks/section %}}
-This is the second section
-{.h1 .text-center}
-{{% /blocks/section %}}
-
-{{% blocks/section type="row" %}}
-
-{{% blocks/feature icon="fab fa-app-store-ios" title="Download **from AppStore**" %}}
-Get the Goldydocs app!
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome!"
-    url="https://github.com/google/docsy-example" %}}
-We do a [Pull Request](https://github.com/google/docsy-example/pulls)
-contributions workflow on **GitHub**. New users are always welcome!
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fab fa-twitter" title="Follow us on Twitter!"
-    url="https://twitter.com/GoHugoIO" %}}
-For announcement of latest features etc.
-{{% /blocks/feature %}}
-
-{{% /blocks/section %}}
-
-
-{{% blocks/section %}}
-This is the another section
-{.h1 .text-center}
-{{% /blocks/section %}} -->
+<!--
+  The home page is rendered by layouts/index.html (custom landing).
+  featured-background.jpg is kept here as a page resource for the group-photo section.
+-->

--- a/content/ko/_index.md
+++ b/content/ko/_index.md
@@ -2,65 +2,7 @@
 title: OpenChain KWG
 ---
 
-{{< blocks/cover title="OpenChain Korea Work Group" image_anchor="top" height="full" >}}
-<a class="btn btn-lg btn-primary me-3 mb-4" href="/OpenChain-KWG/about/">
-  About <i class="fas fa-arrow-alt-circle-right ms-2"></i>
-</a>
-<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/OpenChain-Project/OpenChain-KWG">
-  GitHub <i class="fab fa-github ms-2 "></i>
-</a>
-<p class="lead mt-5">OpenChain KWG is a subgroup of the Linux Foundation OpenChain Project.</p>
-{{< blocks/link-down color="info" >}}
-{{< /blocks/cover >}}
-
-
-{{% blocks/lead color="info" %}}
-OpenChain KWG(Korea Work Group)은 Open Source 정신인 협업과 공유를 통해 모두가 효과적으로 Open Source Compliance를 달성하기 위한 방법을 고민하고 공유하기 위한 모임입니다.
-{{% /blocks/lead %}}
-
-
-{{% blocks/section color="primary" type="row" %}}
-{{% blocks/feature icon="fa-lightbulb" title="Join the Mailing List!" url="/OpenChain-KWG/about/subscribe" %}}
-소프트웨어를 개발하여 배포하는 한국 기업/기관에서 Open Source Compliance 업무를 담당하는 분이라면 참여가 가능합니다.
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fab fa-discord" title="Conllaborate on Discord!" url="https://discord.com/channels/1177116701561729104/" %}}
-Discord에서는 Mailing List보다 다소 가벼운 대화를 하며 멤버들간의 소통이 이루어집니다! 
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/OpenChain-Project/OpenChain-KWG" %}}
-우리의 활동은 GitHub 공개되어 있으며, 모든 형태의 기여를 환영합니다! [Pull Request](https://github.com/OpenChain-Project/OpenChain-KWG/pulls)를 보내주세요!
-{{% /blocks/feature %}}
-
-{{% /blocks/section %}}
-
-
-<!-- {{% blocks/section %}}
-This is the second section
-{.h1 .text-center}
-{{% /blocks/section %}}
-
-{{% blocks/section type="row" %}}
-
-{{% blocks/feature icon="fab fa-app-store-ios" title="Download **from AppStore**" %}}
-Get the Goldydocs app!
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome!"
-    url="https://github.com/google/docsy-example" %}}
-We do a [Pull Request](https://github.com/google/docsy-example/pulls)
-contributions workflow on **GitHub**. New users are always welcome!
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fab fa-twitter" title="Follow us on Twitter!"
-    url="https://twitter.com/GoHugoIO" %}}
-For announcement of latest features etc.
-{{% /blocks/feature %}}
-
-{{% /blocks/section %}}
-
-
-{{% blocks/section %}}
-This is the another section
-{.h1 .text-center}
-{{% /blocks/section %}} -->
+<!--
+  홈 화면은 layouts/index.html(커스텀 랜딩)에서 렌더된다.
+  featured-background.jpg 는 단체사진 섹션용 page resource 로 이 디렉토리에 유지한다.
+-->

--- a/hugo.toml
+++ b/hugo.toml
@@ -27,7 +27,8 @@ category = "categories"
 
 [params.taxonomy]
 # set taxonomyCloud = [] to hide taxonomy clouds
-taxonomyCloud = ["tags", "categories"]
+# 우측 TOC를 Gemini 문서처럼 깔끔하게 유지하기 위해 Tag Cloud 숨김
+taxonomyCloud = []
 
 # If used, must have same length as taxonomyCloud
 taxonomyCloudTitle = ["Tag Cloud", "Categories"]
@@ -87,7 +88,8 @@ description = "An OpenChain KWG site"
       unsafe = true
   [markup.highlight]
     # See a complete list of available styles at https://xyproto.github.io/splash/docs/all.html
-    style = "tango"
+    # github: Gemini 문서풍 밝은 코드 테마(라이트). 다크는 td/chroma/dark 로 보정.
+    style = "github"
     # Uncomment if you want your chosen highlight style used for code blocks without a specified language
     # guessSyntax = "true"
 
@@ -161,7 +163,8 @@ sidebar_menu_compact = true
 ul_show = 1
 sidebar_menu_foldable = true
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-sidebar_search_disable = false
+# 네비바 검색만 남기고 사이드바 검색 중복 제거(Gemini식 상단 단일 검색)
+sidebar_search_disable = true
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.

--- a/hugo.toml
+++ b/hugo.toml
@@ -148,6 +148,8 @@ prism_syntax_highlighting = false
 
 # User interface configuration
 [params.ui]
+# 라이트/다크/자동 테마 토글 메뉴 표시(Docsy 내장, 플래시 방지 스크립트 자동 포함)
+showLightDarkModeMenu = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 # Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top navbar

--- a/layouts/_partials/hooks/head-end.html
+++ b/layouts/_partials/hooks/head-end.html
@@ -1,10 +1,10 @@
 {{- /*
   OpenChain-KWG 웹폰트 주입 — Docsy 공식 head 훅(hooks/head-end.html).
-  영문·숫자: Inter / 한글: Pretendard / 코드: JetBrains Mono.
+  영문·숫자: Roboto(Google Sans와 가까운 계열) / 한글: Pretendard / 코드: JetBrains Mono.
   폰트 스택은 assets/scss/_variables_project.scss($td-fonts-serif)에서 지정한다.
 */ -}}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=JetBrains+Mono:wght@400;500&display=swap">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css">

--- a/layouts/_partials/hooks/head-end.html
+++ b/layouts/_partials/hooks/head-end.html
@@ -1,0 +1,10 @@
+{{- /*
+  OpenChain-KWG 웹폰트 주입 — Docsy 공식 head 훅(hooks/head-end.html).
+  영문·숫자: Inter / 한글: Pretendard / 코드: JetBrains Mono.
+  폰트 스택은 assets/scss/_variables_project.scss($td-fonts-serif)에서 지정한다.
+*/ -}}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css">

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -1,0 +1,81 @@
+{{/*
+  OpenChain-KWG navbar 오버라이드 — Docsy v0.13.0 _partials/navbar.html 복사본.
+  유일한 변경: 원본은 nav에 data-bs-theme="dark"를 항상 박아 네비바를 teal+흰글씨로 고정한다.
+  여기서는 홈 cover(히어로) 위에서만 dark를 유지하고, 일반 문서 페이지에서는 제거해
+  페이지 테마(라이트/다크)를 상속하게 한다 → 화이트 네비바. 배경/보더는 _styles_project.scss.
+  ⚠ 업그레이드 회귀 점검: Docsy 새 버전 navbar.html과 diff 후 변경분(아래 nav 한 줄)만 유지.
+*/ -}}
+{{ $cover := and
+    (.HasShortcode "blocks/cover")
+    (not .Site.Params.ui.navbar_translucent_over_cover_disable)
+-}}
+{{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}
+
+<nav class="td-navbar js-navbar-scroll
+            {{- if $cover }} td-navbar-cover {{- end }}"{{ if $cover }} data-bs-theme="dark"{{ end }}>
+<div class="td-navbar-container container-fluid flex-column flex-md-row">
+  <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+    {{- /**/ -}}
+    <span class="navbar-brand__logo navbar-logo">
+      {{- if ne .Site.Params.ui.navbar_logo false -}}
+        {{ with resources.Get "icons/logo.svg" -}}
+          {{ ( . | minify).Content | safeHTML -}}
+        {{ end -}}
+      {{ end -}}
+    </span>
+    {{- /**/ -}}
+    <span class="navbar-brand__name">
+      {{- .Site.Title -}}
+    </span>
+    {{- /**/ -}}
+  </a>
+  <div class="td-navbar-nav-scroll td-navbar-nav-scroll--indicator" id="main_navbar">
+    <div class="scroll-indicator scroll-left"></div>
+    <ul class="navbar-nav">
+      {{ $p := . -}}
+      {{ range .Site.Menus.main -}}
+      <li class="nav-item">
+        {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
+        {{ $href := "" -}}
+        {{ with .Page -}}
+          {{ $active = or $active ( $.IsDescendant .) -}}
+          {{ $href = .RelPermalink -}}
+        {{ else -}}
+          {{ $href = .URL | relLangURL -}}
+        {{ end -}}
+        {{ $isExternal := ne $baseURL.Host (urls.Parse .URL).Host -}}
+        <a {{/**/ -}}
+          class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
+          href="{{ $href }}"
+          {{- if $isExternal }} target="_blank" rel="noopener" {{- end -}}
+        >
+            {{- .Pre -}}
+            <span>{{ .Name }}</span>
+            {{- .Post -}}
+        </a>
+      </li>
+      {{ end -}}
+      {{ if .Site.Params.versions -}}
+      <li class="nav-item dropdown d-none d-lg-block td-navbar__version-menu">
+        {{ partial "navbar-version-selector.html" . -}}
+      </li>
+      {{ end -}}
+      {{ if (gt (len .Site.Home.Translations) 0) -}}
+      <li class="nav-item td-navbar__lang-menu">
+        {{ partial "navbar-lang-selector.html" . -}}
+      </li>
+      {{ end -}}
+      {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+      {{ if $darkMode.showMenu -}}
+      <li class="nav-item td-navbar__light-dark-menu">
+        {{ partial "theme-toggler" . }}
+      </li>
+      {{ end -}}
+    </ul>
+    <div class="scroll-indicator scroll-right"></div>
+  </div>
+  <div class="d-none d-lg-block td-navbar__search">
+    {{ partial "search-input.html" . }}
+  </div>
+</div>
+</nav>

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -5,8 +5,9 @@
   페이지 테마(라이트/다크)를 상속하게 한다 → 화이트 네비바. 배경/보더는 _styles_project.scss.
   ⚠ 업그레이드 회귀 점검: Docsy 새 버전 navbar.html과 diff 후 변경분(아래 nav 한 줄)만 유지.
 */ -}}
+{{/* 홈(커스텀 다크 히어로)과 blocks/cover 페이지에서 네비바를 투명+흰글씨로 둔다. */}}
 {{ $cover := and
-    (.HasShortcode "blocks/cover")
+    (or (.HasShortcode "blocks/cover") .IsHome)
     (not .Site.Params.ui.navbar_translucent_over_cover_disable)
 -}}
 {{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,133 @@
+{{/*
+  OpenChain-KWG 커스텀 홈 랜딩 — Docsy baseof("main" 블록) 상속.
+  히어로(텍스트) → 단체사진(풀폭) → 가이드 카드 → 참여 → 참여기업 로고.
+  단체사진은 배경이 아니라 독립 섹션으로 두어 얼굴이 가려지지 않게 한다.
+  스타일은 assets/scss/_styles_project.scss(.kwg-*).
+*/}}
+{{ define "main" }}
+{{ $ko := eq .Site.Language.Lang "ko" }}
+<div class="kwg-home">
+
+  {{/* 1. 히어로 — 단체사진 배경 + 다크 그라데이션 오버레이 */}}
+  {{ $bg := "" }}
+  {{ with .Resources.GetMatch "featured-background.jpg" }}{{ $bg = .RelPermalink }}{{ end }}
+  <section class="kwg-hero"{{ with $bg }} style="background-image: linear-gradient(180deg, rgba(6,20,27,0.92) 0%, rgba(6,20,27,0.6) 34%, rgba(6,20,27,0.35) 58%, rgba(6,20,27,0.6) 100%), url('{{ . }}')"{{ end }}>
+    <div class="container kwg-hero__inner">
+      <span class="kwg-hero__badge">Linux Foundation · OpenChain Project</span>
+      <h1 class="kwg-hero__title">OpenChain Korea<br>Work Group</h1>
+      <p class="kwg-hero__sub">
+        {{ if $ko }}한국 기업의 오픈소스 컴플라이언스 담당자들이 모여 지식과 경험을 나누는 커뮤니티입니다.{{ else }}A community where open source compliance practitioners at Korean companies share knowledge and experience.{{ end }}
+      </p>
+      <div class="kwg-hero__cta">
+        <a class="btn btn-lg btn-primary" href="{{ "about/" | relLangURL }}">{{ if $ko }}소개 보기{{ else }}About{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></a>
+        <a class="btn btn-lg btn-outline-primary" href="https://discord.com/channels/1177116701561729104/" target="_blank" rel="noopener">Discord</a>
+      </div>
+    </div>
+  </section>
+
+  {{/* 2. 커뮤니티 참여 */}}
+  <section class="kwg-section container">
+    <div class="kwg-block">
+      <div class="kwg-feature">
+        <div class="kwg-feature__text">
+          <h2 class="kwg-feature__title">{{ if $ko }}커뮤니티 참여{{ else }}Join the community{{ end }}</h2>
+          <p class="kwg-feature__desc">{{ if $ko }}정기 미팅과 온라인 채널에서 한국 기업 오픈소스 컴플라이언스 담당자들과 지식과 경험을 나눕니다.{{ else }}Share knowledge and experience with open source compliance practitioners at Korean companies, through regular meetings and online channels.{{ end }}</p>
+          <a class="kwg-btn-pill" href="{{ "about/" | relLangURL }}">{{ if $ko }}참여 방법 보기{{ else }}How to join{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></a>
+        </div>
+        <div class="kwg-feature__visual" aria-hidden="true">
+          <img class="kwg-tabs__art" src="{{ "images/kwg-viz-community.svg" | relURL }}" alt="">
+        </div>
+      </div>
+      <div class="kwg-subcard-grid kwg-subcard-grid--3">
+        <a class="kwg-subcard" href="{{ "meeting/" | relLangURL }}">
+          <div class="kwg-subcard__body">
+            <h3 class="kwg-subcard__title">{{ if $ko }}정기 미팅{{ else }}Meetings{{ end }}</h3>
+            <p class="kwg-subcard__desc">{{ if $ko }}정기 미팅에서 기업들의 사례와 인사이트를 공유합니다.{{ else }}Regular meetings to share company cases and insights.{{ end }}</p>
+            <span class="kwg-subcard__link">{{ if $ko }}일정 보기{{ else }}Schedule{{ end }} <i class="fa-solid fa-arrow-right"></i></span>
+          </div>
+        </a>
+        <a class="kwg-subcard" href="{{ "about/subscribe/" | relLangURL }}">
+          <div class="kwg-subcard__body">
+            <h3 class="kwg-subcard__title">{{ if $ko }}메일링 리스트{{ else }}Mailing List{{ end }}</h3>
+            <p class="kwg-subcard__desc">{{ if $ko }}오픈소스 컴플라이언스 담당자라면 누구나 참여할 수 있습니다.{{ else }}Open to anyone working on OSS compliance.{{ end }}</p>
+            <span class="kwg-subcard__link">{{ if $ko }}가입하기{{ else }}Subscribe{{ end }} <i class="fa-solid fa-arrow-right"></i></span>
+          </div>
+        </a>
+        <a class="kwg-subcard" href="https://discord.com/channels/1177116701561729104/" target="_blank" rel="noopener">
+          <div class="kwg-subcard__body">
+            <h3 class="kwg-subcard__title">Discord</h3>
+            <p class="kwg-subcard__desc">{{ if $ko }}가벼운 대화와 멤버 간 실시간 소통 공간.{{ else }}Casual, real-time conversation among members.{{ end }}</p>
+            <span class="kwg-subcard__link">{{ if $ko }}참여하기{{ else }}Join{{ end }} <i class="fa-solid fa-arrow-right"></i></span>
+          </div>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  {{/* 3. 핵심 가이드 — 탭 인터페이스(순수 CSS radio) */}}
+  <section class="kwg-section container">
+    <h2 class="kwg-section__title">{{ if $ko }}핵심 가이드{{ else }}Guides{{ end }}</h2>
+    <p class="kwg-section__lead">{{ if $ko }}ISO 국제표준 기반의 기업 오픈소스 컴플라이언스 가이드 — 탭을 눌러 살펴보세요.{{ else }}Enterprise open source compliance guides built on ISO standards — click a tab to explore.{{ end }}</p>
+
+    <div class="kwg-tabs">
+      <input class="kwg-tabs__radio" type="radio" name="kwg-guide" id="gt-1" checked>
+      <input class="kwg-tabs__radio" type="radio" name="kwg-guide" id="gt-2">
+      <input class="kwg-tabs__radio" type="radio" name="kwg-guide" id="gt-3">
+      <input class="kwg-tabs__radio" type="radio" name="kwg-guide" id="gt-4">
+
+      <div class="kwg-tabs__nav">
+        <label for="gt-1">{{ if $ko }}기업 관리 가이드{{ else }}OSS Management{{ end }}</label>
+        <label for="gt-2">ISO/IEC 5230</label>
+        <label for="gt-3">ISO/IEC 18974</label>
+        <label for="gt-4">ISO/IEC 42001</label>
+      </div>
+
+      <a class="kwg-tabs__panel" id="gp-1" href="{{ "guide/opensource_for_enterprise/" | relLangURL }}">
+        <div class="kwg-feature__text">
+          <h3 class="kwg-feature__title">{{ if $ko }}2026 기업 오픈소스 관리 가이드{{ else }}Enterprise OSS Management Guide{{ end }}</h3>
+          <p class="kwg-feature__desc">{{ if $ko }}ISO 국제표준에 기반해 기업이 오픈소스를 도입·관리·배포하는 전 과정을 조직·정책·프로세스 관점에서 단계별로 안내합니다.{{ else }}A step-by-step guide to adopting, managing, and distributing open source across organization, policy, and process — grounded in ISO standards.{{ end }}</p>
+          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></span>
+        </div>
+        <div class="kwg-tabs__visual" aria-hidden="true">
+          <img class="kwg-tabs__art" src="{{ "images/kwg-tab-visual.svg" | relURL }}" alt="">
+        </div>
+      </a>
+
+      <a class="kwg-tabs__panel" id="gp-2" href="{{ "guide/iso5230_guide/" | relLangURL }}">
+        <div class="kwg-feature__text">
+          <h3 class="kwg-feature__title">ISO/IEC 5230</h3>
+          <p class="kwg-feature__desc">{{ if $ko }}오픈소스 라이선스 컴플라이언스 국제표준(OpenChain). 25개 입증자료 항목을 조항별로 풀어 실무 적용을 돕습니다.{{ else }}The international standard for open source license compliance (OpenChain). We break down all 25 evidence items clause by clause.{{ end }}</p>
+          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></span>
+        </div>
+        <div class="kwg-tabs__visual" aria-hidden="true">
+          <img class="kwg-tabs__art" src="{{ "images/kwg-viz-license.svg" | relURL }}" alt="">
+        </div>
+      </a>
+
+      <a class="kwg-tabs__panel" id="gp-3" href="{{ "guide/iso18974_guide/" | relLangURL }}">
+        <div class="kwg-feature__text">
+          <h3 class="kwg-feature__title">ISO/IEC 18974</h3>
+          <p class="kwg-feature__desc">{{ if $ko }}오픈소스 보안 보증(OSS Security Assurance) 국제표준. 보안 취약점 대응 체계를 조항별 입증자료로 안내합니다.{{ else }}The international standard for open source security assurance, guiding vulnerability response with clause-level evidence.{{ end }}</p>
+          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></span>
+        </div>
+        <div class="kwg-tabs__visual" aria-hidden="true">
+          <img class="kwg-tabs__art" src="{{ "images/kwg-viz-security.svg" | relURL }}" alt="">
+        </div>
+      </a>
+
+      <a class="kwg-tabs__panel" id="gp-4" href="{{ "guide/iso42001_guide/" | relLangURL }}">
+        <div class="kwg-feature__text">
+          <h3 class="kwg-feature__title">ISO/IEC 42001</h3>
+          <p class="kwg-feature__desc">{{ if $ko }}AI 관리 시스템(AIMS) 국제표준을 오픈소스 관점에서 풀어, AI 시스템 개발·운영의 핵심 요구사항을 다룹니다.{{ else }}The AI management system (AIMS) standard from an open source perspective, covering key requirements for AI development and operations.{{ end }}</p>
+          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></span>
+        </div>
+        <div class="kwg-tabs__visual" aria-hidden="true">
+          <img class="kwg-tabs__art" src="{{ "images/kwg-viz-ai.svg" | relURL }}" alt="">
+        </div>
+      </a>
+    </div>
+  </section>
+
+
+</div>
+{{ end }}

--- a/static/images/kwg-tab-visual.svg
+++ b/static/images/kwg-tab-visual.svg
@@ -1,0 +1,50 @@
+<svg viewBox="0 0 400 340" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <defs>
+    <radialGradient id="kwgGlow" cx="50%" cy="44%" r="55%">
+      <stop offset="0%" stop-color="#06c8da" stop-opacity="0.5"/>
+      <stop offset="55%" stop-color="#1466d4" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#1466d4" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="kwgTop" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6fe6f0"/>
+      <stop offset="100%" stop-color="#2071de"/>
+    </linearGradient>
+    <linearGradient id="kwgSide" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1c64d4"/>
+      <stop offset="100%" stop-color="#0c3578"/>
+    </linearGradient>
+  </defs>
+
+  <ellipse cx="200" cy="165" rx="175" ry="135" fill="url(#kwgGlow)"/>
+
+  <!-- 점 격자 -->
+  <g fill="#7ff0fa" fill-opacity="0.18">
+    <circle cx="70" cy="90" r="2"/><circle cx="110" cy="70" r="2"/><circle cx="330" cy="100" r="2"/>
+    <circle cx="300" cy="60" r="2"/><circle cx="90" cy="250" r="2"/><circle cx="330" cy="250" r="2"/>
+    <circle cx="60" cy="180" r="2"/><circle cx="345" cy="180" r="2"/>
+  </g>
+
+  <!-- isometric 카드 3단 스택 -->
+  <g stroke="#9ff4fc" stroke-opacity="0.35" stroke-width="1">
+    <g transform="translate(0,52)">
+      <polygon points="200,108 300,166 200,224 100,166" fill="url(#kwgTop)" fill-opacity="0.9"/>
+      <polygon points="100,166 200,224 200,242 100,184" fill="url(#kwgSide)"/>
+      <polygon points="300,166 200,224 200,242 300,184" fill="url(#kwgSide)" fill-opacity="0.78"/>
+    </g>
+    <g transform="translate(0,16)">
+      <polygon points="200,108 300,166 200,224 100,166" fill="url(#kwgTop)" fill-opacity="0.95"/>
+      <polygon points="100,166 200,224 200,242 100,184" fill="url(#kwgSide)"/>
+      <polygon points="300,166 200,224 200,242 300,184" fill="url(#kwgSide)" fill-opacity="0.78"/>
+    </g>
+    <g transform="translate(0,-22)">
+      <polygon points="200,108 300,166 200,224 100,166" fill="url(#kwgTop)"/>
+      <polygon points="100,166 200,224 200,242 100,184" fill="url(#kwgSide)"/>
+      <polygon points="300,166 200,224 200,242 300,184" fill="url(#kwgSide)" fill-opacity="0.78"/>
+    </g>
+  </g>
+
+  <!-- 상단 반짝임 -->
+  <g transform="translate(200,144)" fill="#ffffff">
+    <path d="M0,-13 L3.2,-3.2 L13,0 L3.2,3.2 L0,13 L-3.2,3.2 L-13,0 L-3.2,-3.2 Z" fill-opacity="0.95"/>
+  </g>
+</svg>

--- a/static/images/kwg-viz-ai.svg
+++ b/static/images/kwg-viz-ai.svg
@@ -1,0 +1,36 @@
+<svg viewBox="0 0 400 340" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <defs>
+    <radialGradient id="aGlow" cx="50%" cy="48%" r="55%">
+      <stop offset="0%" stop-color="#06c8da" stop-opacity="0.5"/>
+      <stop offset="55%" stop-color="#1466d4" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#1466d4" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="aNode" cx="40%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="#8af0fa"/>
+      <stop offset="100%" stop-color="#1c5fd0"/>
+    </radialGradient>
+  </defs>
+  <ellipse cx="200" cy="170" rx="175" ry="135" fill="url(#aGlow)"/>
+  <!-- 연결선 -->
+  <g stroke="#7ff0fa" stroke-opacity="0.4" stroke-width="1.5">
+    <line x1="200" y1="170" x2="92" y2="96"/>
+    <line x1="200" y1="170" x2="312" y2="104"/>
+    <line x1="200" y1="170" x2="84" y2="232"/>
+    <line x1="200" y1="170" x2="318" y2="238"/>
+    <line x1="200" y1="170" x2="200" y2="70"/>
+    <line x1="92" y1="96" x2="200" y2="70"/>
+    <line x1="312" y1="104" x2="318" y2="238"/>
+  </g>
+  <!-- 위성 노드 -->
+  <g>
+    <circle cx="92" cy="96" r="13" fill="url(#aNode)"/>
+    <circle cx="312" cy="104" r="11" fill="url(#aNode)"/>
+    <circle cx="84" cy="232" r="11" fill="url(#aNode)"/>
+    <circle cx="318" cy="238" r="14" fill="url(#aNode)"/>
+    <circle cx="200" cy="70" r="10" fill="url(#aNode)"/>
+  </g>
+  <!-- 중앙 노드 -->
+  <circle cx="200" cy="170" r="30" fill="url(#aNode)" stroke="#9ff4fc" stroke-opacity="0.6" stroke-width="1.5"/>
+  <circle cx="200" cy="170" r="30" fill="none" stroke="#7ff0fa" stroke-opacity="0.35" stroke-width="1" transform="translate(0,0)"/>
+  <circle cx="200" cy="170" r="44" fill="none" stroke="#7ff0fa" stroke-opacity="0.25" stroke-width="1"/>
+</svg>

--- a/static/images/kwg-viz-community.svg
+++ b/static/images/kwg-viz-community.svg
@@ -1,0 +1,36 @@
+<svg viewBox="0 0 400 340" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <defs>
+    <radialGradient id="cmGlow" cx="50%" cy="46%" r="55%">
+      <stop offset="0%" stop-color="#06c8da" stop-opacity="0.5"/>
+      <stop offset="55%" stop-color="#1466d4" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#1466d4" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="cmFront" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0%" stop-color="#7fe9f3"/>
+      <stop offset="100%" stop-color="#2071de"/>
+    </linearGradient>
+    <linearGradient id="cmBack" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0%" stop-color="#3ea8e8"/>
+      <stop offset="100%" stop-color="#163d96"/>
+    </linearGradient>
+  </defs>
+  <ellipse cx="200" cy="172" rx="178" ry="138" fill="url(#cmGlow)"/>
+  <g fill="#7ff0fa" fill-opacity="0.18">
+    <circle cx="74" cy="110" r="2"/><circle cx="326" cy="112" r="2"/>
+    <circle cx="92" cy="252" r="2"/><circle cx="312" cy="248" r="2"/>
+  </g>
+
+  <!-- 뒤쪽 두 사람 -->
+  <g fill="url(#cmBack)" opacity="0.9">
+    <circle cx="118" cy="150" r="26"/>
+    <path d="M76,232 a42,42 0 0 1 84,0 Z"/>
+    <circle cx="282" cy="150" r="26"/>
+    <path d="M240,232 a42,42 0 0 1 84,0 Z"/>
+  </g>
+
+  <!-- 가운데 사람(앞, 강조) -->
+  <g fill="url(#cmFront)" stroke="#bff6fc" stroke-opacity="0.35" stroke-width="1.5">
+    <circle cx="200" cy="134" r="34"/>
+    <path d="M146,236 a54,54 0 0 1 108,0 Z"/>
+  </g>
+</svg>

--- a/static/images/kwg-viz-license.svg
+++ b/static/images/kwg-viz-license.svg
@@ -1,0 +1,26 @@
+<svg viewBox="0 0 400 340" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <defs>
+    <radialGradient id="lGlow" cx="50%" cy="46%" r="55%">
+      <stop offset="0%" stop-color="#06c8da" stop-opacity="0.5"/>
+      <stop offset="55%" stop-color="#1466d4" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#1466d4" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="lFace" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6fe6f0"/>
+      <stop offset="100%" stop-color="#2071de"/>
+    </linearGradient>
+  </defs>
+  <ellipse cx="200" cy="170" rx="175" ry="135" fill="url(#lGlow)"/>
+  <g fill="#7ff0fa" fill-opacity="0.18">
+    <circle cx="78" cy="110" r="2"/><circle cx="322" cy="110" r="2"/>
+    <circle cx="70" cy="230" r="2"/><circle cx="330" cy="230" r="2"/>
+  </g>
+  <!-- 동심 isometric 마름모(라이선스 항목이 겹쳐 충족되는 이미지) -->
+  <g stroke="#9ff4fc" stroke-opacity="0.45" fill="none">
+    <polygon points="200,66 326,170 200,274 74,170" stroke-width="1.5" stroke-opacity="0.3"/>
+    <polygon points="200,100 286,170 200,240 114,170" stroke-width="2"/>
+  </g>
+  <polygon points="200,128 252,170 200,212 148,170" fill="url(#lFace)" stroke="#9ff4fc" stroke-opacity="0.5"/>
+  <!-- 체크 -->
+  <path d="M182,170 L196,184 L222,156" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/static/images/kwg-viz-security.svg
+++ b/static/images/kwg-viz-security.svg
@@ -1,0 +1,24 @@
+<svg viewBox="0 0 400 340" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <defs>
+    <radialGradient id="sGlow" cx="50%" cy="46%" r="55%">
+      <stop offset="0%" stop-color="#06c8da" stop-opacity="0.5"/>
+      <stop offset="55%" stop-color="#1466d4" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#1466d4" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="sFace" x1="0" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#6fe6f0"/>
+      <stop offset="100%" stop-color="#1c5fd0"/>
+    </linearGradient>
+  </defs>
+  <ellipse cx="200" cy="170" rx="175" ry="135" fill="url(#sGlow)"/>
+  <g fill="#7ff0fa" fill-opacity="0.18">
+    <circle cx="80" cy="120" r="2"/><circle cx="320" cy="120" r="2"/>
+    <circle cx="90" cy="240" r="2"/><circle cx="310" cy="240" r="2"/>
+  </g>
+  <!-- 방패 -->
+  <path d="M200,62 L300,104 L300,184 C300,238 254,266 200,284 C146,266 100,238 100,184 L100,104 Z"
+        fill="url(#sFace)" fill-opacity="0.92" stroke="#9ff4fc" stroke-opacity="0.5" stroke-width="1.5"/>
+  <path d="M200,62 L200,284 C146,266 100,238 100,184 L100,104 Z" fill="#0c3578" fill-opacity="0.28"/>
+  <!-- 체크 -->
+  <path d="M168,172 L192,198 L240,140" stroke="#ffffff" stroke-width="11" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.95"/>
+</svg>


### PR DESCRIPTION
## 개요
OpenChain KWG 사이트의 UI/UX를 Google AI Studio · Gemini API 문서 수준의 모던한 미감으로 전면 개편한다. Docsy 테마 자동 업그레이드를 유지하기 위해 공식 SCSS 훅 · 내장 기능 · 순수 CSS만 사용한다(JS 추가 없음).

## 변경 (Phase 1~4)
- **Phase 1**: 디자인 토큰(둥근 모서리 · 부드러운 그림자) · 다크모드 토글
- **Phase 2**: 웹폰트(영문 Roboto / 한글 Pretendard / 코드 JetBrains Mono) · 타이포 정렬
- **Phase 3**: 화이트 반투명 네비바, 코드 하이라이트(github), 사이드바 · TOC 경량화, Tag Cloud · 편집 액션 정리, 폰트 크기 정렬
- **Phase 4**: 홈 랜딩 풀 리디자인 — 단체사진 풀스크린 히어로, 순수 CSS 라디오 탭, ISO별 SVG 그래픽, 커뮤니티 섹션

## 업그레이드 안전성
- SCSS 오버라이드 스텁(`_variables_project` / `_variables_project_after_bs` / `_styles_project`), head 훅, hugo.toml params, 내장 다크모드 · 쇼트코드만 사용
- partial 오버라이드는 `navbar.html`(홈 투명 처리)와 커스텀 홈 `index.html`(baseof 상속)뿐 — baseof/single/list 미변경
- Dependabot 자동 머지 유지에 영향 없음

## 점검
- ko/en 양쪽 홈 정상 빌드
- 미사용 CSS 정리 완료
- 로컬 hugo server 빌드 에러 없음