### PR TITLE
히어로 신뢰 요소(통계 띠) 추가

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -290,6 +290,33 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   color: #fff;
 }
 
+// 신뢰 요소 — 통계 띠(미팅·참여 기관·시작 연도)
+.kwg-stats {
+  display: flex;
+  gap: 3rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 3rem;
+}
+.kwg-stats__item { text-align: center; }
+.kwg-stats__num {
+  display: block;
+  font-size: 2.2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  background: linear-gradient(135deg, #9fecf3, #c3b1f7);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.kwg-stats__label {
+  display: block;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: 0.4rem;
+}
+
 // 홈 네비바: 투명 위 흰 글씨(스크롤 시 Docsy navbar-bg-onscroll 가 솔리드 처리)
 .td-home .td-navbar.td-navbar-cover {
   background: transparent;

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -22,6 +22,20 @@
         <a class="btn btn-lg btn-primary" href="{{ "about/" | relLangURL }}">{{ if $ko }}소개 보기{{ else }}About{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></a>
         <a class="btn btn-lg btn-outline-primary" href="https://discord.com/channels/1177116701561729104/" target="_blank" rel="noopener">Discord</a>
       </div>
+      <div class="kwg-stats">
+        <div class="kwg-stats__item">
+          <span class="kwg-stats__num">31</span>
+          <span class="kwg-stats__label">{{ if $ko }}정기 미팅{{ else }}Meetings{{ end }}</span>
+        </div>
+        <div class="kwg-stats__item">
+          <span class="kwg-stats__num">20+</span>
+          <span class="kwg-stats__label">{{ if $ko }}참여 기업·기관{{ else }}Organizations{{ end }}</span>
+        </div>
+        <div class="kwg-stats__item">
+          <span class="kwg-stats__num">2019</span>
+          <span class="kwg-stats__label">{{ if $ko }}함께한 시작{{ else }}Since{{ end }}</span>
+        </div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
SaaS 갭 분석 P1. 히어로에 통계 띠(정기 미팅 31회·참여 기업·기관 20+·2019년 시작)를 추가해 커뮤니티 규모·역사를 노출. 수치는 콘텐츠 기준 보수적 표기.