### PR TITLE
통계 띠를 커뮤니티 참여 블록으로 이동

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -290,13 +290,19 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   color: #fff;
 }
 
-// 신뢰 요소 — 통계 띠(미팅·참여 기관·시작 연도)
+// 신뢰 요소 — 통계 띠(미팅·참여 기관·시작 연도). 커뮤니티 블록 안 피처와 채널 사이 배치
 .kwg-stats {
   display: flex;
   gap: 3rem;
   justify-content: center;
   flex-wrap: wrap;
-  margin-top: 3rem;
+}
+.kwg-stats--block {
+  max-width: 1140px;
+  margin: 0 auto 2.5rem;
+  padding: 1.75rem 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 .kwg-stats__item { text-align: center; }
 .kwg-stats__num {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -22,20 +22,6 @@
         <a class="btn btn-lg btn-primary" href="{{ "about/" | relLangURL }}">{{ if $ko }}소개 보기{{ else }}About{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></a>
         <a class="btn btn-lg btn-outline-primary" href="https://discord.com/channels/1177116701561729104/" target="_blank" rel="noopener">Discord</a>
       </div>
-      <div class="kwg-stats">
-        <div class="kwg-stats__item">
-          <span class="kwg-stats__num">31</span>
-          <span class="kwg-stats__label">{{ if $ko }}정기 미팅{{ else }}Meetings{{ end }}</span>
-        </div>
-        <div class="kwg-stats__item">
-          <span class="kwg-stats__num">20+</span>
-          <span class="kwg-stats__label">{{ if $ko }}참여 기업·기관{{ else }}Organizations{{ end }}</span>
-        </div>
-        <div class="kwg-stats__item">
-          <span class="kwg-stats__num">2019</span>
-          <span class="kwg-stats__label">{{ if $ko }}함께한 시작{{ else }}Since{{ end }}</span>
-        </div>
-      </div>
     </div>
   </section>
 
@@ -52,6 +38,22 @@
           <img class="kwg-tabs__art" src="{{ "images/kwg-viz-community.svg" | relURL }}" alt="">
         </div>
       </div>
+
+      <div class="kwg-stats kwg-stats--block">
+        <div class="kwg-stats__item">
+          <span class="kwg-stats__num">31</span>
+          <span class="kwg-stats__label">{{ if $ko }}정기 미팅{{ else }}Meetings{{ end }}</span>
+        </div>
+        <div class="kwg-stats__item">
+          <span class="kwg-stats__num">20+</span>
+          <span class="kwg-stats__label">{{ if $ko }}참여 기업·기관{{ else }}Organizations{{ end }}</span>
+        </div>
+        <div class="kwg-stats__item">
+          <span class="kwg-stats__num">2019</span>
+          <span class="kwg-stats__label">{{ if $ko }}함께한 시작{{ else }}Since{{ end }}</span>
+        </div>
+      </div>
+
       <div class="kwg-subcard-grid kwg-subcard-grid--3">
         <a class="kwg-subcard" href="{{ "meeting/" | relLangURL }}">
           <div class="kwg-subcard__body">


### PR DESCRIPTION
통계(미팅 31·참여 기관 20+·2019)를 히어로에서 커뮤니티 참여 블록(피처와 채널 사이)으로 이동. 참여 맥락과 일관.