### PR TITLE
30th 미팅 컨퍼런스 홍보형 페이지 + 빌드 캐싱

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -46,6 +46,16 @@ jobs:
           npm ci
           npm run build
 
+      # Hugo 이미지 변환 결과(resources/_gen) 캐싱 — 콜드 빌드 이미지 재처리 방지.
+      # 매 커밋(sha)마다 새로 저장하고, restore-keys 로 직전 캐시를 복원해 변경분만 재처리한다.
+      - name: Cache Hugo resources
+        uses: actions/cache@v4
+        with:
+          path: resources/_gen
+          key: hugo-resources-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            hugo-resources-${{ runner.os }}-
+
       - run: hugo --baseURL https://${REPO_OWNER}.github.io/${REPO_NAME} --minify
 
       - name: Deploy

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -614,3 +614,280 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   .kwg-block { padding: 1.35rem; }
   .kwg-feature__title { font-size: 1.5rem; }
 }
+
+// ── 미팅 컨퍼런스 레이아웃(.kwg-conf-*) — ai.google.dev 미감 ──────
+// 구성은 Gemini API 문서식: 균일한 얇은 테두리 카드·넉넉한 여백·미묘한 그림자·
+// hover elevation. 좌측 강조선/컬러 박스 같은 장식은 쓰지 않는다.
+// 색만 회차별 스폰서 색을 CSS 변수로 주입(.td-content 에 --accent/--ink)하고,
+// 면이 아니라 포인트(CTA 버튼·배지·라벨·링크·옅은 틴트)에만 쓴다.
+// --accent-ink: accent 를 본문 강조색과 섞어 라이트=어둡게/다크=밝게 자동 보정.
+.td-content {
+  --accent-ink: color-mix(in srgb, var(--accent, #ffd400) 52%, var(--bs-emphasis-color));
+}
+
+// 미팅 랜딩 본문 — 폭은 Docsy 문서 컬럼(사이드바·TOC 포함)이 관리. 줄바꿈만 한국어식으로.
+.kwg-conf-landing {
+  word-break: keep-all; // 한국어 단어 단위 줄바꿈(조사 끊김 방지)
+}
+
+// 히어로 — 우상단 은은한 accent 글로우(절제). 큰 타이포 위계.
+.kwg-conf-hero {
+  margin: 0 0 2.5rem;
+  padding: clamp(2rem, 5vw, 3.5rem);
+  border-radius: 1.5rem;
+  border: 1px solid var(--bs-border-color);
+  background:
+    radial-gradient(80% 95% at 100% 0%, color-mix(in srgb, var(--accent, #ffd400) 13%, var(--bs-body-bg)), transparent 52%),
+    var(--bs-body-bg);
+}
+.kwg-conf-hero__eyebrow {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-ink);
+  margin: 0 0 1rem;
+}
+.kwg-conf-hero__title {
+  font-size: clamp(2.1rem, 5vw, 3.1rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.08;
+  color: var(--bs-emphasis-color);
+  margin: 0 0 1.1rem;
+}
+.kwg-conf-hero__sub {
+  font-size: clamp(1.05rem, 2.2vw, 1.3rem);
+  font-weight: 400;
+  color: var(--bs-secondary-color);
+  line-height: 1.55;
+  max-width: 46ch;
+  margin: 0 0 1.75rem;
+}
+.kwg-conf-hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.75rem;
+  font-size: 0.98rem;
+  color: var(--bs-body-color);
+  margin: 0 0 1.75rem;
+}
+.kwg-conf-hero__meta strong { font-weight: 600; color: var(--bs-emphasis-color); margin-right: 0.4rem; }
+
+// CTA — accent 배경 + 어두운 ink 글자(노랑 위 흰 글자 금지)
+.kwg-conf-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.78rem 1.55rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  font-size: 0.98rem;
+  text-decoration: none;
+  background: var(--accent, #ffd400);
+  color: var(--ink, #1a1500);
+  border: 1px solid color-mix(in srgb, var(--accent, #ffd400) 70%, #000);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+.kwg-conf-cta:hover {
+  color: var(--ink, #1a1500);
+  text-decoration: none;
+  transform: translateY(-1px);
+  filter: brightness(1.04);
+  box-shadow: 0 6px 18px rgba(16, 24, 40, 0.14);
+}
+// CTA 묶음(주 + 보조) + 참가 안내 문구
+.kwg-conf-hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+// 보조 CTA(오시는 길) — 아웃라인. 주 CTA(메일링 가입, accent 채움)와 위계 구분
+.kwg-conf-cta--ghost {
+  background: transparent;
+  color: var(--bs-body-color);
+  border: 1px solid var(--bs-border-color);
+}
+.kwg-conf-cta--ghost:hover {
+  background: var(--bs-tertiary-bg);
+  color: var(--bs-body-color);
+  filter: none;
+}
+.kwg-conf-hero__note {
+  margin: 0 0 1.1rem;
+  font-size: 0.88rem;
+  color: var(--bs-secondary-color);
+}
+
+// 키워드 칩 — 절제(뉴트럴 배경)
+.kwg-conf-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0 0 3rem;
+  padding: 0;
+  list-style: none;
+}
+.kwg-conf-chip {
+  padding: 0.3rem 0.8rem;
+  border-radius: 2rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--bs-secondary-color);
+  background: var(--bs-tertiary-bg);
+  border: 1px solid var(--bs-border-color);
+}
+
+// 아젠다 세로 타임라인 — 좌측 세로선 + 시간 노드로 흐름 시각화.
+// 세션은 채운 accent 노드, 휴식은 연한 노드로 위계를 준다.
+.kwg-conf-timeline { margin: 0; }
+.kwg-conf-tl {
+  display: grid;
+  grid-template-columns: 92px 28px 1fr;
+  gap: 0 0.85rem;
+  align-items: stretch;
+}
+.kwg-conf-tl__time {
+  grid-column: 1;
+  text-align: right;
+  padding-top: 0.2rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--accent-ink);
+  font-variant-numeric: tabular-nums;
+}
+// 노드 컬럼 — 세로선(::before) + 점(::after)
+.kwg-conf-tl__marker {
+  grid-column: 2;
+  position: relative;
+}
+.kwg-conf-tl__marker::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--bs-border-color);
+}
+.kwg-conf-tl__marker::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0.45rem;
+  transform: translateX(-50%);
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--bs-body-bg);
+  border: 2px solid var(--bs-secondary-color);
+  z-index: 1;
+}
+// 첫 항목 위쪽 선 제거, 마지막 항목 아래쪽 선 제거
+.kwg-conf-tl:first-child .kwg-conf-tl__marker::before { top: 0.45rem; }
+.kwg-conf-tl:last-child .kwg-conf-tl__marker::before { bottom: auto; height: 0.45rem; }
+.kwg-conf-tl__body {
+  grid-column: 3;
+  padding-bottom: 1.7rem;
+}
+.kwg-conf-tl:last-child .kwg-conf-tl__body { padding-bottom: 0; }
+.kwg-conf-tl__title {
+  font-weight: 600;
+  color: var(--bs-emphasis-color);
+  line-height: 1.4;
+}
+.kwg-conf-tl__by {
+  font-size: 0.88rem;
+  color: var(--bs-secondary-color);
+  margin-top: 0.2rem;
+}
+// 세션 강조 — 채운 accent 노드(약간 크게)
+.kwg-conf-tl--session .kwg-conf-tl__marker::after {
+  width: 13px;
+  height: 13px;
+  top: 0.4rem;
+  background: var(--accent, #ffd400);
+  border-color: var(--accent-ink);
+}
+// 휴식 — 연한 노드 + 흐린 텍스트
+.kwg-conf-tl--muted .kwg-conf-tl__marker::after {
+  border-color: var(--bs-border-color);
+}
+.kwg-conf-tl--muted .kwg-conf-tl__title {
+  font-weight: 500;
+  color: var(--bs-secondary-color);
+}
+
+// 발표자 카드 — 원형 프로필(중립 테두리) + 균일 카드 + hover elevation
+.kwg-conf-speakers {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin: 0;
+}
+.kwg-conf-speaker {
+  padding: 1.75rem 1.4rem;
+  border-radius: 1rem;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.kwg-conf-speaker:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.1);
+}
+.kwg-conf-speaker__photo {
+  width: 132px;
+  height: 132px;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+  margin: 0 auto 1.1rem;
+  border: 1px solid var(--bs-border-color);
+  box-shadow: 0 2px 8px rgba(16, 24, 40, 0.08);
+}
+.kwg-conf-speaker__name {
+  text-align: center;
+  font-weight: 600;
+  color: var(--bs-emphasis-color);
+}
+.kwg-conf-speaker__role {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--accent-ink);
+  margin: 0.15rem 0 0.9rem;
+}
+.kwg-conf-speaker__bio {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--bs-secondary-color);
+  margin: 0;
+}
+
+// 스폰서 블록 — 로고 크기에 맞춘 컴팩트 카드 + 레이블(휑한 풀폭 박스 방지)
+.kwg-conf-sponsor {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1.4rem 2.5rem;
+  border-radius: 1rem;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
+}
+.kwg-conf-sponsor__label {
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+}
+.kwg-conf-sponsor img { max-width: 170px; width: 100%; height: auto; }
+
+@media (max-width: 480px) {
+  .kwg-conf-tl { grid-template-columns: 76px 24px 1fr; gap: 0 0.65rem; }
+  .kwg-conf-tl__time { font-size: 0.82rem; }
+}

--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -1,7 +1,8 @@
 ---
 title: "30th Meeting"
 weight: 30
-type: docs
+type: meeting
+layout: landing
 categories: ["meeting"]
 tags: ["OpenChain", "AI", "governance", "Finance", "KakaoBank"]
 description: >
@@ -10,53 +11,32 @@ aliases:
   - /en/meeting/30th/
 ---
 
-<div style="padding:26px;border-radius:18px;background:linear-gradient(135deg,#ffe812 0%,#ffd400 45%,#ffb800 100%);color:#1a1500;margin-bottom:14px;box-shadow:0 12px 28px rgba(255,184,0,.35);">
-  <p style="margin:0 0 8px 0;letter-spacing:.08em;font-size:12px;font-weight:700;opacity:.75;">OPENCHAIN KOREA WORK GROUP</p>
-  <h1 style="margin:0 0 8px 0;color:#1a1500;">30th Meeting</h1>
-  <p style="margin:0;font-size:18px;"><strong>AI Governance and Open Source Compliance in Finance</strong></p>
-  <p style="margin:12px 0 0 0;font-size:14px;opacity:.85;">2026.06.09 (Tue) 14:00-17:00 · KakaoBank</p>
-</div>
+<style>
+/* Per-meeting sponsor color — for the next meeting, change just these two values. */
+.td-content { --accent: #ffd400; --ink: #1a1500; }
+</style>
 
-<div style="margin:0 0 20px 0;display:flex;flex-wrap:wrap;gap:8px;">
-  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># OpenChain</span>
-  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># AI Governance</span>
-  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># Financial Audit</span>
-  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># OSS Compliance</span>
-</div>
-
-<div style="border:1px solid #f0d860;border-left:4px solid #ffb800;border-radius:10px;padding:12px 14px;background:#fffbeb;margin-bottom:20px;">
-This meeting focuses on <strong>open source governance in the AI era</strong> and <strong>audit readiness checkpoints for the financial sector</strong>,
-sharing practical cases that practitioners can apply immediately.
-</div>
-
-## Event Info
-
-| Item | Details |
-|---|---|
-| Date & Time | **2026-06-09 (Tue) 14:00 – 17:00** |
-| Venue | KakaoBank (Parc.1 Tower 2, 35F, Yeouido) |
-| Location | [Open in Google Maps](https://maps.app.goo.gl/kiA47oQHq3g2jkLd6) |
-| Keywords | `OpenChain` `AI` `Governance` `Finance` |
-
-## Program Highlights
-
-<div style="display:grid;gap:10px;margin-bottom:8px;">
-  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
-    <strong style="color:#8b6914;">Session 1</strong><br>
-    AI-driven Open Source Governance<br>
-    <span style="font-size:13px;color:#6b5a30;">Heonkwan Ha · KakaoBank</span>
+<div class="kwg-conf-hero">
+  <p class="kwg-conf-hero__eyebrow">30th Meeting · Tue, June 9, 2026</p>
+  <h1 class="kwg-conf-hero__title">AI Governance and Open Source Compliance in Finance</h1>
+  <p class="kwg-conf-hero__sub">Practical cases on open source governance in the AI era and audit-readiness checkpoints for the financial sector.</p>
+  <div class="kwg-conf-hero__meta">
+    <span><strong>Date</strong> 2026-06-09 (Tue) 14:00–17:00</span>
+    <span><strong>Venue</strong> KakaoBank · Parc.1 Tower 2, 35F, Yeouido</span>
   </div>
-  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
-    <strong style="color:#8b6914;">Session 2</strong><br>
-    The Impact of Claude Mythos on Open Source<br>
-    <span style="font-size:13px;color:#6b5a30;">Kangbo Kim · AhnLab</span>
-  </div>
-  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
-    <strong style="color:#8b6914;">Session 3</strong><br>
-    Experience Report on Open Source Operations as a Financial Company<br>
-    <span style="font-size:13px;color:#6b5a30;">Minae Lee · KakaoBank</span>
+  <p class="kwg-conf-hero__note">Registration is announced via the OpenChain KWG mailing list. Subscribe to receive the sign-up link.</p>
+  <div class="kwg-conf-hero__cta">
+    <a class="kwg-conf-cta" href="../../../about/subscribe/">Join the mailing list</a>
+    <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://maps.app.goo.gl/kiA47oQHq3g2jkLd6" target="_blank" rel="noopener">Open in Google Maps</a>
   </div>
 </div>
+
+<ul class="kwg-conf-chips">
+  <li class="kwg-conf-chip">OpenChain</li>
+  <li class="kwg-conf-chip">AI Governance</li>
+  <li class="kwg-conf-chip">Financial Audit</li>
+  <li class="kwg-conf-chip">OSS Compliance</li>
+</ul>
 
 ## Who Should Attend
 
@@ -66,66 +46,99 @@ sharing practical cases that practitioners can apply immediately.
 
 ## Agenda
 
-<div style="display:grid;gap:10px;">
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
-    <div style="font-weight:800;color:#8b6914;">14:00-14:10</div>
-    <div><strong>Welcome & Greetings</strong><br><span style="font-size:13px;color:#6b5a30;">Jongseong Kim · KakaoBank</span></div>
+<div class="kwg-conf-timeline">
+  <div class="kwg-conf-tl">
+    <div class="kwg-conf-tl__time">14:00–14:10</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Welcome &amp; Greetings</div>
+      <div class="kwg-conf-tl__by">Jongseong Kim · KakaoBank</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
-    <div style="font-weight:800;color:#8b6914;">14:10-14:30</div>
-    <div><strong>OpenChain Updates</strong><br><span style="font-size:13px;color:#6b5a30;">Steering Committee</span></div>
+  <div class="kwg-conf-tl">
+    <div class="kwg-conf-tl__time">14:10–14:30</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">OpenChain Updates</div>
+      <div class="kwg-conf-tl__by">Steering Committee</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
-    <div style="font-weight:800;color:#8b6914;">14:30-14:55</div>
-    <div><strong>Session 1. AI-driven Open Source Governance</strong><br><span style="font-size:13px;color:#6b5a30;">Heonkwan Ha · KakaoBank</span></div>
+  <div class="kwg-conf-tl kwg-conf-tl--session">
+    <div class="kwg-conf-tl__time">14:30–14:55</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Session 1. AI-driven Open Source Governance</div>
+      <div class="kwg-conf-tl__by">Heonkwan Ha · KakaoBank</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px dashed #e8d880;border-radius:12px;padding:12px 14px;background:#fffef0;">
-    <div style="font-weight:800;color:#8b6914;">14:55-15:15</div>
-    <div><strong>Break & Networking</strong><br><span style="font-size:13px;color:#6b5a30;">Coffee break</span></div>
+  <div class="kwg-conf-tl kwg-conf-tl--muted">
+    <div class="kwg-conf-tl__time">14:55–15:15</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Break &amp; Networking</div>
+      <div class="kwg-conf-tl__by">Coffee break</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
-    <div style="font-weight:800;color:#8b6914;">15:15-15:40</div>
-    <div><strong>Session 2. The Impact of Claude Mythos on Open Source</strong><br><span style="font-size:13px;color:#6b5a30;">Kangbo Kim · AhnLab</span></div>
+  <div class="kwg-conf-tl kwg-conf-tl--session">
+    <div class="kwg-conf-tl__time">15:15–15:40</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Session 2. The Impact of Claude Mythos on Open Source</div>
+      <div class="kwg-conf-tl__by">Kangbo Kim · AhnLab</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
-    <div style="font-weight:800;color:#8b6914;">15:40-16:05</div>
-    <div><strong>Session 3. Experience Report on Open Source Operations as a Financial Company</strong><br><span style="font-size:13px;color:#6b5a30;">Minae Lee · KakaoBank</span></div>
+  <div class="kwg-conf-tl kwg-conf-tl--session">
+    <div class="kwg-conf-tl__time">15:40–16:05</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Session 3. Experience Report on Open Source Operations as a Financial Company</div>
+      <div class="kwg-conf-tl__by">Minae Lee · KakaoBank</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
-    <div style="font-weight:800;color:#8b6914;">16:05-16:50</div>
-    <div><strong>Group Discussion</strong><br><span style="font-size:13px;color:#6b5a30;">All Participants</span></div>
+  <div class="kwg-conf-tl">
+    <div class="kwg-conf-tl__time">16:05–16:50</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Group Discussion</div>
+      <div class="kwg-conf-tl__by">All Participants</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
-    <div style="font-weight:800;color:#8b6914;">16:50-17:00</div>
-    <div><strong>Closing & Group Photo</strong><br><span style="font-size:13px;color:#6b5a30;">Steering Committee</span></div>
+  <div class="kwg-conf-tl">
+    <div class="kwg-conf-tl__time">16:50–17:00</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Closing &amp; Group Photo</div>
+      <div class="kwg-conf-tl__by">Steering Committee</div>
+    </div>
   </div>
 </div>
 
 ## Speakers
 
-<div style="display:flex;flex-wrap:wrap;gap:16px;margin-top:8px;">
-  <div style="flex:1 1 260px;border:1px solid #f0e8c0;border-radius:12px;padding:18px 16px;background:#fffef8;">
-    <img src="heonkwan-ha.png" alt="Heonkwan Ha" style="width:120px;height:120px;object-fit:cover;border-radius:50%;display:block;margin:0 auto 12px;">
-    <div style="text-align:center;font-weight:800;color:#8b6914;">Heonkwan Ha, Manager</div>
-    <div style="text-align:center;font-size:13px;color:#6b5a30;margin:2px 0 12px;">KakaoBank · Session 1</div>
-    <p style="font-size:14px;line-height:1.6;margin:0;">Open source governance, DevSecOps, and CMDB operations at KakaoBank.</p>
+<div class="kwg-conf-speakers">
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" src="heonkwan-ha.png" alt="Heonkwan Ha">
+    <div class="kwg-conf-speaker__name">Heonkwan Ha, Manager</div>
+    <div class="kwg-conf-speaker__role">KakaoBank · Session 1</div>
+    <p class="kwg-conf-speaker__bio">Open source governance, DevSecOps, and CMDB operations at KakaoBank.</p>
   </div>
-  <div style="flex:1 1 260px;border:1px solid #f0e8c0;border-radius:12px;padding:18px 16px;background:#fffef8;">
-    <img src="kangbo-kim.png" alt="Kangbo Kim" style="width:120px;height:120px;object-fit:cover;border-radius:50%;display:block;margin:0 auto 12px;">
-    <div style="text-align:center;font-weight:800;color:#8b6914;">Kangbo Kim, Team Lead</div>
-    <div style="text-align:center;font-size:13px;color:#6b5a30;margin:2px 0 12px;">AhnLab · Session 2</div>
-    <p style="font-size:14px;line-height:1.6;margin:0;">Team Lead of the Research Infrastructure Team at AhnLab. He designs and operates R&D development-support environments — CI/CD infrastructure, OSS (Open Source Software) verification, static analysis, development-process standardization, build and signing, and patent and external-project management. His main focus is open source compliance and security-vulnerability response for security products, and building a static-analysis-centered CI/CD pipeline spanning development through release.</p>
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" src="kangbo-kim.png" alt="Kangbo Kim">
+    <div class="kwg-conf-speaker__name">Kangbo Kim, Team Lead</div>
+    <div class="kwg-conf-speaker__role">AhnLab · Session 2</div>
+    <p class="kwg-conf-speaker__bio">Team Lead of the Research Infrastructure Team at AhnLab. He designs and operates R&amp;D development-support environments — CI/CD infrastructure, OSS (Open Source Software) verification, static analysis, development-process standardization, build and signing, and patent and external-project management. His main focus is open source compliance and security-vulnerability response for security products, and building a static-analysis-centered CI/CD pipeline spanning development through release.</p>
   </div>
-  <div style="flex:1 1 260px;border:1px solid #f0e8c0;border-radius:12px;padding:18px 16px;background:#fffef8;">
-    <img src="minae-lee.png" alt="Minae Lee" style="width:120px;height:120px;object-fit:cover;border-radius:50%;display:block;margin:0 auto 12px;">
-    <div style="text-align:center;font-weight:800;color:#8b6914;">Minae Lee, Manager</div>
-    <div style="text-align:center;font-size:13px;color:#6b5a30;margin:2px 0 12px;">KakaoBank · Session 3</div>
-    <p style="font-size:14px;line-height:1.6;margin:0;">Open source governance at KakaoBank, in-house IT policy, and internal/external audit response.</p>
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" src="minae-lee.png" alt="Minae Lee">
+    <div class="kwg-conf-speaker__name">Minae Lee, Manager</div>
+    <div class="kwg-conf-speaker__role">KakaoBank · Session 3</div>
+    <p class="kwg-conf-speaker__bio">Open source governance at KakaoBank, in-house IT policy, and internal/external audit response.</p>
   </div>
 </div>
 
 ## Sponsor
 
-<div style="text-align:center;padding:16px 12px;border:1px solid #f0d860;border-radius:12px;background:linear-gradient(180deg,#fffef5 0%,#fff9db 100%);">
-  <img src="../../../../images/content/about/logo/kakaobank.png" alt="KakaoBank" style="max-width:220px;width:100%;height:auto;">
+<div class="kwg-conf-sponsor">
+  <span class="kwg-conf-sponsor__label">Sponsored by</span>
+  <img src="../../../../images/content/about/logo/kakaobank.png" alt="KakaoBank">
 </div>

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -1,7 +1,8 @@
 ---
 title: "30th Meeting"
 weight: 30
-type: docs
+type: meeting
+layout: landing
 categories: ["meeting"]
 tags: ["OpenChain", "AI", "governance", "금융", "KakaoBank"]
 description: >
@@ -10,122 +11,135 @@ aliases:
   - /meeting/30th/
 ---
 
-<div style="padding:26px;border-radius:18px;background:linear-gradient(135deg,#ffe812 0%,#ffd400 45%,#ffb800 100%);color:#1a1500;margin-bottom:14px;box-shadow:0 12px 28px rgba(255,184,0,.35);">
-  <p style="margin:0 0 8px 0;letter-spacing:.08em;font-size:12px;font-weight:700;opacity:.75;">OPENCHAIN KOREA WORK GROUP</p>
-  <h1 style="margin:0 0 8px 0;color:#1a1500;">30th Meeting</h1>
-  <p style="margin:0;font-size:18px;"><strong>AI 거버넌스와 금융권 오픈소스 컴플라이언스</strong></p>
-  <p style="margin:12px 0 0 0;font-size:14px;opacity:.85;">2026.06.09 (화) 14:00-17:00 · 카카오뱅크</p>
-</div>
+<style>
+/* 회차별 스폰서 색 — 다음 회차는 이 두 값만 그 스폰서 색으로 교체. */
+.td-content { --accent: #ffd400; --ink: #1a1500; }
+</style>
 
-<div style="margin:0 0 20px 0;display:flex;flex-wrap:wrap;gap:8px;">
-  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># OpenChain</span>
-  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># AI Governance</span>
-  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># 금융권 Audit</span>
-  <span style="padding:6px 10px;border-radius:999px;border:1px solid #e8c840;background:#fffde7;font-size:12px;font-weight:700;color:#6b5200;"># OSS Compliance</span>
-</div>
-
-<div style="border:1px solid #f0d860;border-left:4px solid #ffb800;border-radius:10px;padding:12px 14px;background:#fffbeb;margin-bottom:20px;">
-이번 미팅은 <strong>AI 시대의 오픈소스 거버넌스 실무</strong>와 <strong>금융권 감사 대응 체크포인트</strong>를 중심으로,
-현업 담당자들이 바로 적용할 수 있는 사례를 공유합니다.
-</div>
-
-## 행사 정보
-
-| 항목 | 내용 |
-|---|---|
-| 일시 | **2026-06-09 (화) 14:00 ~ 17:00** |
-| 장소 | 카카오뱅크 (여의도 파크원 타워2 35층) |
-| 위치 | [Google Maps 바로가기](https://maps.app.goo.gl/kiA47oQHq3g2jkLd6) |
-| 키워드 | `OpenChain` `AI` `Governance` `금융` |
-
-## 프로그램 하이라이트
-
-<div style="display:grid;gap:10px;margin-bottom:8px;">
-  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
-    <strong style="color:#8b6914;">Session 1</strong><br>
-    AI-driven Open Source Governance<br>
-    <span style="font-size:13px;color:#6b5a30;">하헌관 · 카카오뱅크</span>
+<div class="kwg-conf-hero">
+  <p class="kwg-conf-hero__eyebrow">30th Meeting · 2026.06.09 (화)</p>
+  <h1 class="kwg-conf-hero__title">AI 거버넌스와 금융권 오픈소스 컴플라이언스</h1>
+  <p class="kwg-conf-hero__sub">AI 시대의 오픈소스 거버넌스 실무와 금융권 감사 대응 체크포인트를 현업 사례로 공유합니다.</p>
+  <div class="kwg-conf-hero__meta">
+    <span><strong>일시</strong> 2026-06-09 (화) 14:00–17:00</span>
+    <span><strong>장소</strong> 카카오뱅크 · 여의도 파크원 타워2 35층</span>
   </div>
-  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
-    <strong style="color:#8b6914;">Session 2</strong><br>
-    Claude Mythos가 Open Source에 미치는 영향<br>
-    <span style="font-size:13px;color:#6b5a30;">김강보 · 안랩</span>
-  </div>
-  <div style="border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fffef5;border-left:4px solid #ffd400;">
-    <strong style="color:#8b6914;">Session 3</strong><br>
-    금융회사로서의 오픈소스 관련 업무 대응 후기<br>
-    <span style="font-size:13px;color:#6b5a30;">이민애 · 카카오뱅크</span>
+  <p class="kwg-conf-hero__note">참가 신청은 OpenChain KWG 메일링리스트로 안내됩니다. 가입하시면 신청 링크를 받아보실 수 있습니다.</p>
+  <div class="kwg-conf-hero__cta">
+    <a class="kwg-conf-cta" href="../../../about/subscribe/">메일링리스트 가입</a>
+    <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.naver.com/p/search/%ED%8C%8C%ED%81%AC%EC%9B%90%20%ED%83%80%EC%9B%8C2" target="_blank" rel="noopener">네이버지도</a>
+    <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.kakao.com/link/search/%ED%8C%8C%ED%81%AC%EC%9B%90%20%ED%83%80%EC%9B%8C2" target="_blank" rel="noopener">카카오맵</a>
   </div>
 </div>
+
+<ul class="kwg-conf-chips">
+  <li class="kwg-conf-chip">OpenChain</li>
+  <li class="kwg-conf-chip">AI Governance</li>
+  <li class="kwg-conf-chip">금융권 Audit</li>
+  <li class="kwg-conf-chip">OSS Compliance</li>
+</ul>
 
 ## 이런 분께 추천
 
-- 금융/규제 산업에서 오픈소스 컴플라이언스 정책을 운영하는 담당자
+- 금융·규제 산업에서 오픈소스 컴플라이언스 정책을 운영하는 담당자
 - AI 도입 이후 오픈소스 거버넌스 범위를 재정의해야 하는 조직
-- 감사/점검 대응을 위한 체크리스트와 증적 관리가 필요한 팀
+- 감사·점검 대응을 위한 체크리스트와 증적 관리가 필요한 팀
 
 ## 아젠다
 
-<div style="display:grid;gap:10px;">
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
-    <div style="font-weight:800;color:#8b6914;">14:00-14:10</div>
-    <div><strong>Welcome & Greetings</strong><br><span style="font-size:13px;color:#6b5a30;">카카오뱅크 기술기획팀장 김종성 팀장</span></div>
+<div class="kwg-conf-timeline">
+  <div class="kwg-conf-tl">
+    <div class="kwg-conf-tl__time">14:00–14:10</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Welcome &amp; Greetings</div>
+      <div class="kwg-conf-tl__by">카카오뱅크 기술기획팀장 김종성</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
-    <div style="font-weight:800;color:#8b6914;">14:10-14:30</div>
-    <div><strong>OpenChain Updates</strong><br><span style="font-size:13px;color:#6b5a30;">운영진</span></div>
+  <div class="kwg-conf-tl">
+    <div class="kwg-conf-tl__time">14:10–14:30</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">OpenChain Updates</div>
+      <div class="kwg-conf-tl__by">운영진</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
-    <div style="font-weight:800;color:#8b6914;">14:30-14:55</div>
-    <div><strong>Session 1. AI-driven Open Source Governance</strong><br><span style="font-size:13px;color:#6b5a30;">하헌관 · 카카오뱅크</span></div>
+  <div class="kwg-conf-tl kwg-conf-tl--session">
+    <div class="kwg-conf-tl__time">14:30–14:55</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Session 1. AI-driven Open Source Governance</div>
+      <div class="kwg-conf-tl__by">하헌관 · 카카오뱅크</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px dashed #e8d880;border-radius:12px;padding:12px 14px;background:#fffef0;">
-    <div style="font-weight:800;color:#8b6914;">14:55-15:15</div>
-    <div><strong>휴식 및 네트워킹</strong><br><span style="font-size:13px;color:#6b5a30;">Coffee break</span></div>
+  <div class="kwg-conf-tl kwg-conf-tl--muted">
+    <div class="kwg-conf-tl__time">14:55–15:15</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">휴식 및 네트워킹</div>
+      <div class="kwg-conf-tl__by">Coffee break</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
-    <div style="font-weight:800;color:#8b6914;">15:15-15:40</div>
-    <div><strong>Session 2. Claude Mythos가 Open Source에 미치는 영향</strong><br><span style="font-size:13px;color:#6b5a30;">김강보 · 안랩</span></div>
+  <div class="kwg-conf-tl kwg-conf-tl--session">
+    <div class="kwg-conf-tl__time">15:15–15:40</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Session 2. Claude Mythos가 Open Source에 미치는 영향</div>
+      <div class="kwg-conf-tl__by">김강보 · 안랩</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0d860;border-radius:12px;padding:12px 14px;background:#fff9db;border-left:4px solid #ffd400;">
-    <div style="font-weight:800;color:#8b6914;">15:40-16:05</div>
-    <div><strong>Session 3. 금융회사로서의 오픈소스 관련 업무 대응 후기</strong><br><span style="font-size:13px;color:#6b5a30;">이민애 · 카카오뱅크</span></div>
+  <div class="kwg-conf-tl kwg-conf-tl--session">
+    <div class="kwg-conf-tl__time">15:40–16:05</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">Session 3. 금융회사로서의 오픈소스 관련 업무 대응 후기</div>
+      <div class="kwg-conf-tl__by">이민애 · 카카오뱅크</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
-    <div style="font-weight:800;color:#8b6914;">16:05-16:50</div>
-    <div><strong>그룹 토의</strong><br><span style="font-size:13px;color:#6b5a30;">All Participants</span></div>
+  <div class="kwg-conf-tl">
+    <div class="kwg-conf-tl__time">16:05–16:50</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">그룹 토의</div>
+      <div class="kwg-conf-tl__by">All Participants</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;border:1px solid #f0e8c0;border-radius:12px;padding:12px 14px;background:#fffef8;">
-    <div style="font-weight:800;color:#8b6914;">16:50-17:00</div>
-    <div><strong>마무리 및 단체 사진 촬영</strong><br><span style="font-size:13px;color:#6b5a30;">운영진</span></div>
+  <div class="kwg-conf-tl">
+    <div class="kwg-conf-tl__time">16:50–17:00</div>
+    <div class="kwg-conf-tl__marker"></div>
+    <div class="kwg-conf-tl__body">
+      <div class="kwg-conf-tl__title">마무리 및 단체 사진 촬영</div>
+      <div class="kwg-conf-tl__by">운영진</div>
+    </div>
   </div>
 </div>
 
 ## 발표자 소개
 
-<div style="display:flex;flex-wrap:wrap;gap:16px;margin-top:8px;">
-  <div style="flex:1 1 260px;border:1px solid #f0e8c0;border-radius:12px;padding:18px 16px;background:#fffef8;">
-    <img src="heonkwan-ha.png" alt="하헌관 매니저" style="width:120px;height:120px;object-fit:cover;border-radius:50%;display:block;margin:0 auto 12px;">
-    <div style="text-align:center;font-weight:800;color:#8b6914;">하헌관 매니저</div>
-    <div style="text-align:center;font-size:13px;color:#6b5a30;margin:2px 0 12px;">카카오뱅크 · Session 1</div>
-    <p style="font-size:14px;line-height:1.6;margin:0;">카카오뱅크 오픈소스 거버넌스, DevSecOps, CMDB 운영</p>
+<div class="kwg-conf-speakers">
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" src="heonkwan-ha.png" alt="하헌관 매니저">
+    <div class="kwg-conf-speaker__name">하헌관 매니저</div>
+    <div class="kwg-conf-speaker__role">카카오뱅크 · Session 1</div>
+    <p class="kwg-conf-speaker__bio">카카오뱅크 오픈소스 거버넌스, DevSecOps, CMDB 운영</p>
   </div>
-  <div style="flex:1 1 260px;border:1px solid #f0e8c0;border-radius:12px;padding:18px 16px;background:#fffef8;">
-    <img src="kangbo-kim.png" alt="김강보 팀장" style="width:120px;height:120px;object-fit:cover;border-radius:50%;display:block;margin:0 auto 12px;">
-    <div style="text-align:center;font-weight:800;color:#8b6914;">김강보 팀장</div>
-    <div style="text-align:center;font-size:13px;color:#6b5a30;margin:2px 0 12px;">안랩 · Session 2</div>
-    <p style="font-size:14px;line-height:1.6;margin:0;">안랩 연구인프라팀에서 팀장으로 근무하며, CI/CD 인프라 구축을 비롯해 OSS(Open Source Software) 검증, 정적 분석, 개발 프로세스 정립, 배포 및 서명, 특허와 외부 과제 관리 등 R&D 전반의 개발 지원 환경을 설계·운영하고 있습니다. 특히 보안 제품을 구성하는 오픈소스의 컴플라이언스 준수와 보안 취약점 대응, 그리고 정적 분석을 중심으로 한 개발부터 배포까지 이어지는 CI/CD 체계 구축을 주요 업무로 담당하고 있습니다.</p>
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" src="kangbo-kim.png" alt="김강보 팀장">
+    <div class="kwg-conf-speaker__name">김강보 팀장</div>
+    <div class="kwg-conf-speaker__role">안랩 · Session 2</div>
+    <p class="kwg-conf-speaker__bio">안랩 연구인프라팀에서 팀장으로 근무하며, CI/CD 인프라 구축을 비롯해 OSS(Open Source Software) 검증, 정적 분석, 개발 프로세스 정립, 배포 및 서명, 특허와 외부 과제 관리 등 R&D 전반의 개발 지원 환경을 설계·운영하고 있습니다. 특히 보안 제품을 구성하는 오픈소스의 컴플라이언스 준수와 보안 취약점 대응, 그리고 정적 분석을 중심으로 한 개발부터 배포까지 이어지는 CI/CD 체계 구축을 주요 업무로 담당하고 있습니다.</p>
   </div>
-  <div style="flex:1 1 260px;border:1px solid #f0e8c0;border-radius:12px;padding:18px 16px;background:#fffef8;">
-    <img src="minae-lee.png" alt="이민애 매니저" style="width:120px;height:120px;object-fit:cover;border-radius:50%;display:block;margin:0 auto 12px;">
-    <div style="text-align:center;font-weight:800;color:#8b6914;">이민애 매니저</div>
-    <div style="text-align:center;font-size:13px;color:#6b5a30;margin:2px 0 12px;">카카오뱅크 · Session 3</div>
-    <p style="font-size:14px;line-height:1.6;margin:0;">카카오뱅크 오픈소스 거버넌스, 사내 IT 업무 관련 정책 담당, 내외부감사 대응</p>
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" src="minae-lee.png" alt="이민애 매니저">
+    <div class="kwg-conf-speaker__name">이민애 매니저</div>
+    <div class="kwg-conf-speaker__role">카카오뱅크 · Session 3</div>
+    <p class="kwg-conf-speaker__bio">카카오뱅크 오픈소스 거버넌스, 사내 IT 업무 관련 정책 담당, 내외부감사 대응</p>
   </div>
 </div>
 
 ## Sponsor
 
-<div style="text-align:center;padding:16px 12px;border:1px solid #f0d860;border-radius:12px;background:linear-gradient(180deg,#fffef5 0%,#fff9db 100%);">
-  <img src="../../../images/content/about/logo/kakaobank.png" alt="KakaoBank" style="max-width:220px;width:100%;height:auto;">
+<div class="kwg-conf-sponsor">
+  <span class="kwg-conf-sponsor__label">이번 미팅 후원</span>
+  <img src="../../../images/content/about/logo/kakaobank.png" alt="KakaoBank">
 </div>

--- a/layouts/meeting/baseof.html
+++ b/layouts/meeting/baseof.html
@@ -1,0 +1,46 @@
+{{/*
+  OpenChain-KWG 미팅용 baseof — Docsy docs/baseof.html 과 동일(사이드바·TOC·breadcrumb 유지).
+  목적: type=meeting 페이지가 docs 문서 레이아웃(좌측 회차 트리·우측 TOC·breadcrumb)을 그대로
+  쓰도록 한다. 본문 영역(main 블록)만 meeting/landing.html 이 .Content 로 채워, 자동 h1·
+  description·Tags/Categories·lastmod 같은 문서 메타 중복을 제거한다.
+  ⚠ Docsy 업그레이드 시 docs/baseof.html 변경분을 이 파일에 반영할 것(회귀 점검 대상).
+*/ -}}
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js"
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main" {{- partialCached "td/scrollspy-attr.txt" . .Section | safeHTMLAttr }}>
+        <div class="row flex-xl-nowrap">
+          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+            {{ partial "sidebar.html" . }}
+          </aside>
+          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+            {{ partial "page-meta-links.html" . }}
+            {{ partial "toc.html" . }}
+            {{ partial "taxonomy_terms_clouds.html" . }}
+          </aside>
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
+            {{ partial "version-banner.html" . }}
+            {{ if not (.Param "ui.breadcrumb_disable") -}}
+              {{ partial "breadcrumb.html" . -}}
+            {{ end -}}
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/meeting/landing.html
+++ b/layouts/meeting/landing.html
@@ -1,0 +1,12 @@
+{{/*
+  OpenChain-KWG 미팅 홍보형 랜딩 — Docsy 풀폭 baseof("main" 블록) 상속.
+  문서용 chrome(좌측 사이드바·우측 TOC·breadcrumb·Tags/Categories·lastmod)을 걷어내고
+  본문(.Content)만 적정 폭으로 가운데 배치한다.
+  프런트매터 `type: meeting` + `layout: landing` 로 원하는 미팅에만 선택 적용한다.
+  본문 스타일은 assets/scss/_styles_project.scss(.kwg-conf-*).
+*/}}
+{{ define "main" }}
+<div class="td-content kwg-conf-landing">
+  {{ .Content }}
+</div>
+{{ end }}


### PR DESCRIPTION
## 변경 내용

### 30th 미팅 페이지 개편 (홍보형)
- `layouts/meeting/` 전용 레이아웃 — 사이드바·TOC·breadcrumb는 유지하되 본문 자동 메타(h1·description·Tags·lastmod) 중복 제거
- `.kwg-conf-*` 스타일 신설 — 스폰서 색을 CSS 변수(`--accent`/`--ink`)로 토큰화해 회차별 교체 가능, Bootstrap 테마 변수 기반 라이트/다크 호환
- 히어로(절제된 accent 글로우) · 세로 타임라인 아젠다 · 발표자 카드 · 컴팩트 스폰서 블록
- 참가 안내: 메일링리스트 가입을 주 CTA로, 안내문을 버튼 위에 배치
- 오시는 길: ko는 네이버지도·카카오맵, en은 Google Maps

### 빌드 캐싱
- GitHub Actions에 Hugo `resources/_gen` 캐싱 추가 — 콜드 빌드 이미지 재처리 방지

ko/en 동기화 완료. `hugo --minify` 빌드 정상.