### PR TITLE
미팅 사이드바에 회차·연월·주최 표시(linkTitle)

### DIFF
--- a/content/en/meeting/2023/17th/_index.md
+++ b/content/en/meeting/2023/17th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "17th Meeting"
+linkTitle: "17th · 2023.03 Line Plus"
 weight: 17
 type: docs
 description: >

--- a/content/en/meeting/2023/18th/_index.md
+++ b/content/en/meeting/2023/18th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "18th Meeting"
+linkTitle: "18th · 2023.06 Kakao"
 weight: 18
 type: docs
 description: >

--- a/content/en/meeting/2023/19th/_index.md
+++ b/content/en/meeting/2023/19th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "19th Meeting"
+linkTitle: "19th · 2023.09 Hyundai Autoever"
 weight: 19
 type: docs
 description: >

--- a/content/en/meeting/2023/20th/_index.md
+++ b/content/en/meeting/2023/20th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "20th Meeting"
+linkTitle: "20th · 2023.11 Samsung Electronics Seocho Headquarters"
 weight: 20
 type: docs
 description: >

--- a/content/en/meeting/2024/21st/_index.md
+++ b/content/en/meeting/2024/21st/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "21st Meeting"
+linkTitle: "21st · 2024.03 Kakao Pangyo Azit"
 weight: 21
 type: docs
 description: >

--- a/content/en/meeting/2024/22nd/_index.md
+++ b/content/en/meeting/2024/22nd/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "22nd Meeting"
+linkTitle: "22nd · 2024.06 CJ Talent Training Center"
 weight: 22
 type: docs
 description: >

--- a/content/en/meeting/2024/23rd/_index.md
+++ b/content/en/meeting/2024/23rd/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "23rd Meeting"
+linkTitle: "23rd · 2024.09 ETRI Seoul Office"
 weight: 23
 type: docs
 # categories: ["meeting"]

--- a/content/en/meeting/2024/24th/_index.md
+++ b/content/en/meeting/2024/24th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "24th Meeting"
+linkTitle: "24th · 2024.11 LG AI Research"
 weight: 24
 type: docs
 # categories: ["meeting"]

--- a/content/en/meeting/2025/25th/_index.md
+++ b/content/en/meeting/2025/25th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "25th Meeting"
+linkTitle: "25th · 2025.03 Raon Secure"
 weight: 25
 type: docs
 categories: ["meeting"]

--- a/content/en/meeting/2025/26th/_index.md
+++ b/content/en/meeting/2025/26th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "26th Meeting"
+linkTitle: "26th · 2025.06 Samsung Electronics"
 weight: 26
 type: docs
 categories: ["meeting"]

--- a/content/en/meeting/2025/27th/_index.md
+++ b/content/en/meeting/2025/27th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "27th Meeting"
+linkTitle: "27th · 2025.10 ETRI Open Source Tech Day 2025"
 weight: 27
 type: docs
 categories: ["meeting"]

--- a/content/en/meeting/2025/28th/_index.md
+++ b/content/en/meeting/2025/28th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "28th Meeting"
+linkTitle: "28th · 2025.12 Hancom"
 weight: 28
 type: docs
 categories: ["meeting"]

--- a/content/en/meeting/2026/29th/_index.md
+++ b/content/en/meeting/2026/29th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "29th Meeting"
+linkTitle: "29th · 2026.03 Line Plus"
 weight: 29
 type: docs
 categories: ["meeting"]

--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "30th Meeting"
+linkTitle: "30th · 2026.06 KakaoBank"
 weight: 30
 type: meeting
 layout: landing

--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "31th Meeting"
+linkTitle: "31th · 2026.09 CJ"
 date: 2026-03-31T17:23:41+09:00
 weight: 31
 type: docs

--- a/content/ko/meeting/2023/17th/_index.md
+++ b/content/ko/meeting/2023/17th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "17th Meeting"
+linkTitle: "17th · 2023.03 라인플러스"
 weight: 17
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2023/18th/_index.md
+++ b/content/ko/meeting/2023/18th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "18th Meeting"
+linkTitle: "18th · 2023.06 카카오"
 weight: 18
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2023/19th/_index.md
+++ b/content/ko/meeting/2023/19th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "19th Meeting"
+linkTitle: "19th · 2023.09 현대오토에버"
 weight: 19
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2023/20th/_index.md
+++ b/content/ko/meeting/2023/20th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "20th Meeting"
+linkTitle: "20th · 2023.11 삼성전자 서초사옥"
 weight: 20
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2024/21st/_index.md
+++ b/content/ko/meeting/2024/21st/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "21st Meeting"
+linkTitle: "21st · 2024.03 카카오 판교아지트"
 weight: 21
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2024/22nd/_index.md
+++ b/content/ko/meeting/2024/22nd/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "22nd Meeting"
+linkTitle: "22nd · 2024.06 CJ Talent Training Center"
 weight: 22
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2024/23rd/_index.md
+++ b/content/ko/meeting/2024/23rd/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "23rd Meeting"
+linkTitle: "23rd · 2024.09 ETRI 서울사무소"
 weight: 23
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2024/24th/_index.md
+++ b/content/ko/meeting/2024/24th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "24th Meeting"
+linkTitle: "24th · 2024.11 LG AI 연구원"
 weight: 24
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2025/25th/_index.md
+++ b/content/ko/meeting/2025/25th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "25th Meeting"
+linkTitle: "25th · 2025.03 한국디지털인증협회"
 weight: 25
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2025/26th/_index.md
+++ b/content/ko/meeting/2025/26th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "26th Meeting"
+linkTitle: "26th · 2025.06 삼성전자"
 weight: 26
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2025/27th/_index.md
+++ b/content/ko/meeting/2025/27th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "27th Meeting"
+linkTitle: "27th · 2025.10 오픈소스 테크데이"
 weight: 27
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2025/28th/_index.md
+++ b/content/ko/meeting/2025/28th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "28th Meeting"
+linkTitle: "28th · 2025.12 한컴"
 weight: 28
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2026/29th/_index.md
+++ b/content/ko/meeting/2026/29th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "29th Meeting"
+linkTitle: "29th · 2026.03 라인플러스"
 weight: 29
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "30th Meeting"
+linkTitle: "30th · 2026.06 카카오뱅크"
 weight: 30
 type: meeting
 layout: landing

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "31th Meeting"
+linkTitle: "31th · 2026.09 CJ"
 date: 2026-03-31T17:19:04+09:00
 weight: 31
 type: docs


### PR DESCRIPTION
## 변경 내용
17th~31st 미팅 `_index.md`(ko/en, 30파일)에 `linkTitle` 추가.

- 사이드바·breadcrumb 표시명을 `Nth · YYYY.MM 주최기관`으로 — 메뉴 이름만으로 언제·어디서 열렸는지 파악 가능
- 페이지 `title`·브라우저 탭·본문은 불변(linkTitle 라인만 추가)
- `description`에서 자동 추출
- 1st~16th는 description 형식이 비표준(영어·온라인 위주)이라 이번 범위에서 제외

`hugo --minify` 빌드 정상.