### PR TITLE
미팅 사이드바 linkTitle 회사명만 남기기

### DIFF
--- a/content/en/meeting/2023/20th/_index.md
+++ b/content/en/meeting/2023/20th/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "20th Meeting"
-linkTitle: "20th · 2023.11 Samsung Electronics Seocho Headquarters"
+linkTitle: "20th · 2023.11 Samsung Electronics"
 weight: 20
 type: docs
 description: >

--- a/content/en/meeting/2024/21st/_index.md
+++ b/content/en/meeting/2024/21st/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "21st Meeting"
-linkTitle: "21st · 2024.03 Kakao Pangyo Azit"
+linkTitle: "21st · 2024.03 Kakao"
 weight: 21
 type: docs
 description: >

--- a/content/en/meeting/2024/22nd/_index.md
+++ b/content/en/meeting/2024/22nd/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "22nd Meeting"
-linkTitle: "22nd · 2024.06 CJ Talent Training Center"
+linkTitle: "22nd · 2024.06 CJ"
 weight: 22
 type: docs
 description: >

--- a/content/en/meeting/2024/23rd/_index.md
+++ b/content/en/meeting/2024/23rd/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "23rd Meeting"
-linkTitle: "23rd · 2024.09 ETRI Seoul Office"
+linkTitle: "23rd · 2024.09 ETRI"
 weight: 23
 type: docs
 # categories: ["meeting"]

--- a/content/ko/meeting/2023/20th/_index.md
+++ b/content/ko/meeting/2023/20th/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "20th Meeting"
-linkTitle: "20th · 2023.11 삼성전자 서초사옥"
+linkTitle: "20th · 2023.11 삼성전자"
 weight: 20
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2024/21st/_index.md
+++ b/content/ko/meeting/2024/21st/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "21st Meeting"
-linkTitle: "21st · 2024.03 카카오 판교아지트"
+linkTitle: "21st · 2024.03 카카오"
 weight: 21
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2024/22nd/_index.md
+++ b/content/ko/meeting/2024/22nd/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "22nd Meeting"
-linkTitle: "22nd · 2024.06 CJ Talent Training Center"
+linkTitle: "22nd · 2024.06 CJ"
 weight: 22
 type: docs
 categories: ["meeting"]

--- a/content/ko/meeting/2024/23rd/_index.md
+++ b/content/ko/meeting/2024/23rd/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "23rd Meeting"
-linkTitle: "23rd · 2024.09 ETRI 서울사무소"
+linkTitle: "23rd · 2024.09 ETRI"
 weight: 23
 type: docs
 categories: ["meeting"]


### PR DESCRIPTION
20·21·22·23회차의 사이드바 linkTitle에서 장소 수식어(서초사옥·판교아지트·Talent Training Center·서울사무소)를 제거하고 회사명만 남김. 24th(LG AI 연구원)·25th·27th(행사명)는 정식명이라 유지.