### PR TITLE
히어로 날짜 블록 + Actions Node 24 업그레이드

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -21,7 +21,7 @@ jobs:
       pages: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
           extended: true
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -49,7 +49,7 @@ jobs:
       # Hugo 이미지 변환 결과(resources/_gen) 캐싱 — 콜드 빌드 이미지 재처리 방지.
       # 매 커밋(sha)마다 새로 저장하고, restore-keys 로 직전 캐시를 복원해 변경분만 재처리한다.
       - name: Cache Hugo resources
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: resources/_gen
           key: hugo-resources-${{ runner.os }}-${{ github.sha }}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -630,7 +630,7 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   word-break: keep-all; // 한국어 단어 단위 줄바꿈(조사 끊김 방지)
 }
 
-// 히어로 — 우상단 은은한 accent 글로우(절제). 큰 타이포 위계.
+// 히어로 — 우상단 은은한 accent 글로우(절제). 좌(본문) + 우(날짜 블록) 2열.
 .kwg-conf-hero {
   margin: 0 0 2.5rem;
   padding: clamp(2rem, 5vw, 3.5rem);
@@ -639,6 +639,40 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   background:
     radial-gradient(80% 95% at 100% 0%, color-mix(in srgb, var(--accent, #ffd400) 13%, var(--bs-body-bg)), transparent 52%),
     var(--bs-body-bg);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1.5rem 2.5rem;
+  align-items: start;
+}
+.kwg-conf-hero__body { min-width: 0; }
+// 우측 날짜 블록 — 빈 공간 보강. 큰 '일' + 작은 연월/요일.
+.kwg-conf-hero__date {
+  text-align: center;
+  align-self: start;
+  padding: 1.1rem 1.4rem;
+  border-radius: 1rem;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  box-shadow: 0 2px 8px rgba(16, 24, 40, 0.06);
+}
+.kwg-conf-hero__date-d {
+  display: block;
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--accent-ink);
+}
+.kwg-conf-hero__date-my {
+  display: block;
+  margin-top: 0.4rem;
+  font-size: 0.82rem;
+  color: var(--bs-secondary-color);
+  white-space: nowrap;
+}
+@media (max-width: 600px) {
+  .kwg-conf-hero { grid-template-columns: 1fr; }
+  .kwg-conf-hero__date { justify-self: start; }
 }
 .kwg-conf-hero__eyebrow {
   font-size: 0.8rem;

--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -18,17 +18,23 @@ aliases:
 </style>
 
 <div class="kwg-conf-hero">
-  <p class="kwg-conf-hero__eyebrow">30th Meeting · Tue, June 9, 2026</p>
-  <h1 class="kwg-conf-hero__title">AI Governance and Open Source Compliance in Finance</h1>
-  <p class="kwg-conf-hero__sub">Practical cases on open source governance in the AI era and audit-readiness checkpoints for the financial sector.</p>
-  <div class="kwg-conf-hero__meta">
-    <span><strong>Date</strong> 2026-06-09 (Tue) 14:00–17:00</span>
-    <span><strong>Venue</strong> KakaoBank · Parc.1 Tower 2, 35F, Yeouido</span>
+  <div class="kwg-conf-hero__body">
+    <p class="kwg-conf-hero__eyebrow">30th Meeting</p>
+    <h1 class="kwg-conf-hero__title">AI Governance and Open Source Compliance in Finance</h1>
+    <p class="kwg-conf-hero__sub">Practical cases on open source governance in the AI era and audit-readiness checkpoints for the financial sector.</p>
+    <div class="kwg-conf-hero__meta">
+      <span><strong>Date</strong> 2026-06-09 (Tue) 14:00–17:00</span>
+      <span><strong>Venue</strong> KakaoBank · Parc.1 Tower 2, 35F, Yeouido</span>
+    </div>
+    <p class="kwg-conf-hero__note">Registration is announced via the OpenChain KWG mailing list. Subscribe to receive the sign-up link.</p>
+    <div class="kwg-conf-hero__cta">
+      <a class="kwg-conf-cta" href="../../../about/subscribe/">Join the mailing list</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://maps.app.goo.gl/kiA47oQHq3g2jkLd6" target="_blank" rel="noopener">Open in Google Maps</a>
+    </div>
   </div>
-  <p class="kwg-conf-hero__note">Registration is announced via the OpenChain KWG mailing list. Subscribe to receive the sign-up link.</p>
-  <div class="kwg-conf-hero__cta">
-    <a class="kwg-conf-cta" href="../../../about/subscribe/">Join the mailing list</a>
-    <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://maps.app.goo.gl/kiA47oQHq3g2jkLd6" target="_blank" rel="noopener">Open in Google Maps</a>
+  <div class="kwg-conf-hero__date">
+    <span class="kwg-conf-hero__date-d">09</span>
+    <span class="kwg-conf-hero__date-my">Jun 2026 · Tue</span>
   </div>
 </div>
 

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -18,18 +18,24 @@ aliases:
 </style>
 
 <div class="kwg-conf-hero">
-  <p class="kwg-conf-hero__eyebrow">30th Meeting · 2026.06.09 (화)</p>
-  <h1 class="kwg-conf-hero__title">AI 거버넌스와 금융권 오픈소스 컴플라이언스</h1>
-  <p class="kwg-conf-hero__sub">AI 시대의 오픈소스 거버넌스 실무와 금융권 감사 대응 체크포인트를 현업 사례로 공유합니다.</p>
-  <div class="kwg-conf-hero__meta">
-    <span><strong>일시</strong> 2026-06-09 (화) 14:00–17:00</span>
-    <span><strong>장소</strong> 카카오뱅크 · 여의도 파크원 타워2 35층</span>
+  <div class="kwg-conf-hero__body">
+    <p class="kwg-conf-hero__eyebrow">30th Meeting</p>
+    <h1 class="kwg-conf-hero__title">AI 거버넌스와 금융권 오픈소스 컴플라이언스</h1>
+    <p class="kwg-conf-hero__sub">AI 시대의 오픈소스 거버넌스 실무와 금융권 감사 대응 체크포인트를 현업 사례로 공유합니다.</p>
+    <div class="kwg-conf-hero__meta">
+      <span><strong>일시</strong> 2026-06-09 (화) 14:00–17:00</span>
+      <span><strong>장소</strong> 카카오뱅크 · 여의도 파크원 타워2 35층</span>
+    </div>
+    <p class="kwg-conf-hero__note">참가 신청은 OpenChain KWG 메일링리스트로 안내됩니다. 가입하시면 신청 링크를 받아보실 수 있습니다.</p>
+    <div class="kwg-conf-hero__cta">
+      <a class="kwg-conf-cta" href="../../../about/subscribe/">메일링리스트 가입</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.naver.com/p/search/%ED%8C%8C%ED%81%AC%EC%9B%90%20%ED%83%80%EC%9B%8C2" target="_blank" rel="noopener">네이버지도</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.kakao.com/link/search/%ED%8C%8C%ED%81%AC%EC%9B%90%20%ED%83%80%EC%9B%8C2" target="_blank" rel="noopener">카카오맵</a>
+    </div>
   </div>
-  <p class="kwg-conf-hero__note">참가 신청은 OpenChain KWG 메일링리스트로 안내됩니다. 가입하시면 신청 링크를 받아보실 수 있습니다.</p>
-  <div class="kwg-conf-hero__cta">
-    <a class="kwg-conf-cta" href="../../../about/subscribe/">메일링리스트 가입</a>
-    <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.naver.com/p/search/%ED%8C%8C%ED%81%AC%EC%9B%90%20%ED%83%80%EC%9B%8C2" target="_blank" rel="noopener">네이버지도</a>
-    <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.kakao.com/link/search/%ED%8C%8C%ED%81%AC%EC%9B%90%20%ED%83%80%EC%9B%8C2" target="_blank" rel="noopener">카카오맵</a>
+  <div class="kwg-conf-hero__date">
+    <span class="kwg-conf-hero__date-d">09</span>
+    <span class="kwg-conf-hero__date-my">2026년 6월 · 화</span>
   </div>
 </div>
 


### PR DESCRIPTION
## 변경
- **ci**: GitHub Actions를 Node 24 지원 버전으로 — checkout@v6, setup-node@v6, cache@v5 (2026-09-16 Node 20 제거 대비)
- **design**: 30th 히어로를 좌(본문)/우(날짜 블록) 2열로 재구성, 우측 빈 공간 보강. 모바일 세로 스택.

hugo --minify 빌드 정상.