### PR TITLE
UI/UX 고도화 (Phase 1~5) + 홈 히어로 정비

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -233,23 +233,31 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-hero__inner { position: relative; z-index: 1; width: 100%; }
 .kwg-hero__badge {
   display: inline-block;
-  padding: 0.45rem 1.1rem;
-  margin-bottom: 1.75rem;
+  padding: $space-2 $space-4;
+  margin-bottom: $space-6;
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 2rem;
   background: rgba(255, 255, 255, 0.06);
   backdrop-filter: blur(8px);
-  font-size: 0.82rem;
+  font-size: $text-sm;
   font-weight: 500;
   letter-spacing: 0.01em;
   color: rgba(255, 255, 255, 0.82);
+  text-decoration: none;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+// 배지가 링크일 때 — 클릭 가능 암시(hover 시 밝게)
+a.kwg-hero__badge:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.4);
+  color: #fff;
 }
 .kwg-hero__title {
-  font-size: 4.25rem;
+  font-size: 4.25rem; // 거대 디스플레이(타입 스케일 예외)
   font-weight: 600;
   letter-spacing: -0.04em;
   line-height: 1.04;
-  margin-bottom: 1.5rem;
+  margin-bottom: $space-5;
   background: linear-gradient(120deg, #ffffff 35%, #9fecf3 70%, #c3b1f7);
   -webkit-background-clip: text;
   background-clip: text;
@@ -257,16 +265,16 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   color: transparent;
 }
 .kwg-hero__sub {
-  font-size: 1.3rem;
+  font-size: $text-xl;
   color: rgba(255, 255, 255, 0.75);
   max-width: 620px;
-  margin: 0 auto 2.5rem;
+  margin: 0 auto $space-7;
   line-height: 1.6;
 }
-.kwg-hero__cta { display: flex; gap: 0.85rem; justify-content: center; flex-wrap: wrap; }
+.kwg-hero__cta { display: flex; gap: $space-3; justify-content: center; flex-wrap: wrap; }
 .kwg-hero__cta .btn-primary {
   border-radius: 2rem;
-  padding: 0.75rem 1.7rem;
+  padding: $space-3 $space-5;
   font-weight: 500;
   background: linear-gradient(135deg, $primary, $secondary);
   border: none;
@@ -279,7 +287,7 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 }
 .kwg-hero__cta .btn-outline-primary {
   border-radius: 2rem;
-  padding: 0.75rem 1.7rem;
+  padding: $space-3 $space-5;
   color: #fff;
   border-color: rgba(255, 255, 255, 0.35);
   backdrop-filter: blur(8px);
@@ -293,22 +301,22 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 // 신뢰 요소 — 통계 띠(미팅·참여 기관·시작 연도). 커뮤니티 블록 안 피처와 채널 사이 배치
 .kwg-stats {
   display: flex;
-  gap: 3rem;
+  gap: $space-8;
   justify-content: center;
   flex-wrap: wrap;
 }
 // 피처(소개) 텍스트 안에 통합 — 좌측 정렬, 작게
 .kwg-stats--inline {
   justify-content: flex-start;
-  gap: 2rem;
-  margin: 1.5rem 0;
+  gap: $space-6;
+  margin: $space-5 0;
 }
-.kwg-stats--inline .kwg-stats__num { font-size: 1.8rem; }
-.kwg-stats--inline .kwg-stats__label { font-size: 0.78rem; }
+.kwg-stats--inline .kwg-stats__num { font-size: 1.8rem; } // 숫자 디스플레이(예외)
+.kwg-stats--inline .kwg-stats__label { font-size: $text-xs; }
 .kwg-stats__item { text-align: center; }
 .kwg-stats__num {
   display: block;
-  font-size: 2.2rem;
+  font-size: 2.2rem; // 숫자 디스플레이(예외)
   font-weight: 700;
   letter-spacing: -0.02em;
   line-height: 1;
@@ -319,9 +327,9 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 }
 .kwg-stats__label {
   display: block;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: rgba(255, 255, 255, 0.7);
-  margin-top: 0.4rem;
+  margin-top: $space-2;
 }
 
 // 홈 네비바: 투명 위 흰 글씨(스크롤 시 Docsy navbar-bg-onscroll 가 솔리드 처리)
@@ -334,17 +342,17 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-section { padding: 6.5rem 0; }
 .kwg-section--alt { background: var(--bs-tertiary-bg); }
 .kwg-section__title {
-  font-size: 2.4rem;
+  font-size: 2.4rem; // 섹션 제목 디스플레이(예외)
   font-weight: 600;
   letter-spacing: -0.03em;
   text-align: center;
-  margin-bottom: 0.75rem;
+  margin-bottom: $space-3;
 }
 .kwg-section__lead {
   text-align: center;
-  font-size: 1.1rem;
+  font-size: $text-lg;
   color: var(--bs-secondary-color);
-  margin-bottom: 3.5rem;
+  margin-bottom: $space-8;
 }
 
 // 큰 컨테이너 블록 (ai.google.dev식 섹션 카드: 피처 + 서브카드를 함께 감쌈)
@@ -352,7 +360,7 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-block {
   max-width: 1140px;
   margin: 0 auto;
-  padding: 3rem 3.25rem;
+  padding: $space-8;
   border-radius: 1.75rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background:
@@ -365,32 +373,32 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-feature {
   display: grid;
   grid-template-columns: 1.05fr 1fr;
-  gap: 2.5rem;
+  gap: $space-7;
   align-items: center;
   max-width: 1140px;
-  margin: 0 auto 2.5rem;
+  margin: 0 auto $space-7;
 }
 .kwg-feature__title {
-  font-size: 2.1rem;
+  font-size: 2.1rem; // 피처 제목 디스플레이(예외)
   font-weight: 600;
   letter-spacing: -0.03em;
   line-height: 1.15;
   color: #fff;
-  margin-bottom: 1.1rem;
+  margin-bottom: $space-4;
 }
 .kwg-feature__desc {
-  font-size: 1.02rem;
+  font-size: $text-base;
   color: rgba(255, 255, 255, 0.62);
   line-height: 1.7;
-  margin-bottom: 1.75rem;
+  margin-bottom: $space-6;
   max-width: 460px;
 }
 .kwg-btn-pill {
   display: inline-block;
-  padding: 0.7rem 1.6rem;
+  padding: $space-3 $space-5;
   border-radius: 2rem;
   font-weight: 500;
-  font-size: 0.95rem;
+  font-size: $text-base;
   color: #fff;
   text-decoration: none;
   background: linear-gradient(135deg, $primary, $secondary);
@@ -425,18 +433,18 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 // 탭바: 하나의 둥근 묶음 안에서 선택된 탭이 채워짐 → '탭' 인지가 명확
 .kwg-tabs__nav {
   display: inline-flex;
-  gap: 0.25rem;
-  padding: 0.35rem;
-  margin-bottom: 1.75rem;
+  gap: $space-1;
+  padding: $space-1;
+  margin-bottom: $space-6;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 2rem;
 }
 .kwg-tabs__nav label {
-  padding: 0.55rem 1.3rem;
+  padding: $space-2 $space-5;
   border-radius: 2rem;
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   font-weight: 500;
   color: rgba(255, 255, 255, 0.72);
   white-space: nowrap;
@@ -454,11 +462,11 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-tabs__panel {
   display: none;
   grid-template-columns: 1fr 1fr;
-  gap: 3rem;
+  gap: $space-8;
   align-items: center;
   max-width: 1140px;
   margin: 0 auto;
-  padding: 3rem 3.25rem;
+  padding: $space-8;
   border-radius: 1.75rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background:
@@ -496,15 +504,15 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-subcard-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.25rem;
+  gap: $space-5;
   max-width: 1140px;
   margin: 0 auto;
 }
 .kwg-subcard-grid--3 { grid-template-columns: repeat(3, 1fr); }
 .kwg-subcard {
   display: flex;
-  gap: 1.25rem;
-  padding: 1.25rem;
+  gap: $space-5;
+  padding: $space-5;
   border-radius: 1rem;
   background: rgba(255, 255, 255, 0.025);
   border: 1px solid rgba(255, 255, 255, 0.07);
@@ -518,28 +526,28 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 }
 .kwg-subcard__body { display: flex; flex-direction: column; min-width: 0; }
 .kwg-subcard__title {
-  font-size: 1.05rem;
+  font-size: $text-base;
   font-weight: 600;
   color: #fff;
-  margin-bottom: 0.35rem;
+  margin-bottom: $space-1;
 }
 .kwg-subcard__desc {
-  font-size: 0.88rem;
+  font-size: $text-sm;
   color: rgba(255, 255, 255, 0.6);
   line-height: 1.55;
-  margin-bottom: 0.85rem;
+  margin-bottom: $space-3;
   flex-grow: 1;
 }
 .kwg-subcard__link {
   align-self: flex-start;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.9rem;
+  gap: $space-2;
+  padding: $space-1 $space-3;
   border-radius: 2rem;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  font-size: 0.8rem;
+  font-size: $text-xs;
   color: rgba(255, 255, 255, 0.85);
   transition: background 0.18s ease, border-color 0.18s ease;
 }
@@ -552,10 +560,34 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-home {
   background: #060b11;
   color: rgba(255, 255, 255, 0.85);
+  position: relative;
 
   .kwg-section--alt { background: rgba(255, 255, 255, 0.03); }
   .kwg-section__title { color: #fff; }
   .kwg-section__lead { color: rgba(255, 255, 255, 0.72); }
+}
+// 추상 비주얼 — 은은한 컬러 메시(고정 레이어). 히어로(사진)는 위에서 가리고,
+// 그 아래 다크 섹션들에 미묘한 청록·보라 분위기를 깐다(ai.google.dev/Stripe식).
+.kwg-home::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(38% 28% at 16% 12%, rgba(2, 171, 184, 0.13), transparent 70%),
+    radial-gradient(32% 24% at 88% 26%, rgba(195, 177, 247, 0.10), transparent 70%),
+    radial-gradient(34% 30% at 72% 84%, rgba(159, 236, 243, 0.07), transparent 72%);
+}
+.kwg-home > * { position: relative; z-index: 1; }
+
+// 인라인 SVG 아이콘 — Font Awesome 화살표를 대체(일관된 stroke 아이콘)
+.kwg-icon {
+  display: inline-block;
+  vertical-align: -0.15em;
+  margin-left: 0.3em;
+  width: 1em;
+  height: 1em;
 }
 
 // 태블릿 — 좌우 분할(피처·탭 패널)을 세로로 전환해 좁아짐 방지
@@ -632,8 +664,8 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 
 // 히어로 — 우상단 은은한 accent 글로우(절제). 좌(본문) + 우(날짜 블록) 2열.
 .kwg-conf-hero {
-  margin: 0 0 2.5rem;
-  padding: clamp(2rem, 5vw, 3.5rem);
+  margin: 0 0 $space-7;
+  padding: clamp($space-6, 5vw, 3.5rem);
   border-radius: 1.5rem;
   border: 1px solid var(--bs-border-color);
   background:
@@ -641,7 +673,7 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
     var(--bs-body-bg);
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 1.5rem 2.5rem;
+  gap: $space-5 $space-7;
   align-items: start;
 }
 .kwg-conf-hero__body { min-width: 0; }
@@ -649,7 +681,7 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-conf-hero__date {
   text-align: center;
   align-self: start;
-  padding: 1.1rem 1.4rem;
+  padding: $space-4 $space-5;
   border-radius: 1rem;
   background: var(--bs-body-bg);
   border: 1px solid var(--bs-border-color);
@@ -665,8 +697,8 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 }
 .kwg-conf-hero__date-my {
   display: block;
-  margin-top: 0.4rem;
-  font-size: 0.82rem;
+  margin-top: $space-2;
+  font-size: $text-sm;
   color: var(--bs-secondary-color);
   white-space: nowrap;
 }
@@ -675,12 +707,12 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   .kwg-conf-hero__date { justify-self: start; }
 }
 .kwg-conf-hero__eyebrow {
-  font-size: 0.8rem;
+  font-size: $text-xs;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--accent-ink);
-  margin: 0 0 1rem;
+  margin: 0 0 $space-4;
 }
 .kwg-conf-hero__title {
   font-size: clamp(2.1rem, 5vw, 3.1rem);
@@ -688,7 +720,7 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   letter-spacing: -0.03em;
   line-height: 1.08;
   color: var(--bs-emphasis-color);
-  margin: 0 0 1.1rem;
+  margin: 0 0 $space-4;
 }
 .kwg-conf-hero__sub {
   font-size: clamp(1.05rem, 2.2vw, 1.3rem);
@@ -696,27 +728,27 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   color: var(--bs-secondary-color);
   line-height: 1.55;
   max-width: 46ch;
-  margin: 0 0 1.75rem;
+  margin: 0 0 $space-6;
 }
 .kwg-conf-hero__meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem 1.75rem;
-  font-size: 0.98rem;
+  gap: $space-2 $space-6;
+  font-size: $text-base;
   color: var(--bs-body-color);
-  margin: 0 0 1.75rem;
+  margin: 0 0 $space-6;
 }
-.kwg-conf-hero__meta strong { font-weight: 600; color: var(--bs-emphasis-color); margin-right: 0.4rem; }
+.kwg-conf-hero__meta strong { font-weight: 600; color: var(--bs-emphasis-color); margin-right: $space-2; }
 
 // CTA — accent 배경 + 어두운 ink 글자(노랑 위 흰 글자 금지)
 .kwg-conf-cta {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.78rem 1.55rem;
+  gap: $space-2;
+  padding: $space-3 $space-5;
   border-radius: 0.75rem;
   font-weight: 600;
-  font-size: 0.98rem;
+  font-size: $text-base;
   text-decoration: none;
   background: var(--accent, #ffd400);
   color: var(--ink, #1a1500);
@@ -734,7 +766,7 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-conf-hero__cta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.7rem;
+  gap: $space-3;
 }
 // 보조 CTA(오시는 길) — 아웃라인. 주 CTA(메일링 가입, accent 채움)와 위계 구분
 .kwg-conf-cta--ghost {
@@ -748,8 +780,8 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   filter: none;
 }
 .kwg-conf-hero__note {
-  margin: 0 0 1.1rem;
-  font-size: 0.88rem;
+  margin: 0 0 $space-4;
+  font-size: $text-sm;
   color: var(--bs-secondary-color);
 }
 
@@ -757,15 +789,15 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-conf-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin: 0 0 3rem;
+  gap: $space-2;
+  margin: 0 0 $space-8;
   padding: 0;
   list-style: none;
 }
 .kwg-conf-chip {
-  padding: 0.3rem 0.8rem;
+  padding: $space-1 $space-3;
   border-radius: 2rem;
-  font-size: 0.8rem;
+  font-size: $text-xs;
   font-weight: 500;
   color: var(--bs-secondary-color);
   background: var(--bs-tertiary-bg);
@@ -778,15 +810,15 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-conf-tl {
   display: grid;
   grid-template-columns: 92px 28px 1fr;
-  gap: 0 0.85rem;
+  gap: 0 $space-3;
   align-items: stretch;
 }
 .kwg-conf-tl__time {
   grid-column: 1;
   text-align: right;
-  padding-top: 0.2rem;
+  padding-top: $space-1;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   color: var(--accent-ink);
   font-variant-numeric: tabular-nums;
 }
@@ -823,7 +855,7 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-conf-tl:last-child .kwg-conf-tl__marker::before { bottom: auto; height: 0.45rem; }
 .kwg-conf-tl__body {
   grid-column: 3;
-  padding-bottom: 1.7rem;
+  padding-bottom: $space-5;
 }
 .kwg-conf-tl:last-child .kwg-conf-tl__body { padding-bottom: 0; }
 .kwg-conf-tl__title {
@@ -832,9 +864,9 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   line-height: 1.4;
 }
 .kwg-conf-tl__by {
-  font-size: 0.88rem;
+  font-size: $text-sm;
   color: var(--bs-secondary-color);
-  margin-top: 0.2rem;
+  margin-top: $space-1;
 }
 // 세션 강조 — 채운 accent 노드(약간 크게)
 .kwg-conf-tl--session .kwg-conf-tl__marker::after {
@@ -857,11 +889,11 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-conf-speakers {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1.25rem;
+  gap: $space-5;
   margin: 0;
 }
 .kwg-conf-speaker {
-  padding: 1.75rem 1.4rem;
+  padding: $space-6 $space-5;
   border-radius: 1rem;
   background: var(--bs-body-bg);
   border: 1px solid var(--bs-border-color);
@@ -878,7 +910,7 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   object-fit: cover;
   border-radius: 50%;
   display: block;
-  margin: 0 auto 1.1rem;
+  margin: 0 auto $space-4;
   border: 1px solid var(--bs-border-color);
   box-shadow: 0 2px 8px rgba(16, 24, 40, 0.08);
 }
@@ -889,12 +921,12 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 }
 .kwg-conf-speaker__role {
   text-align: center;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: var(--accent-ink);
-  margin: 0.15rem 0 0.9rem;
+  margin: $space-1 0 $space-4;
 }
 .kwg-conf-speaker__bio {
-  font-size: 0.9rem;
+  font-size: $text-sm;
   line-height: 1.6;
   color: var(--bs-secondary-color);
   margin: 0;
@@ -905,15 +937,15 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.85rem;
-  padding: 1.4rem 2.5rem;
+  gap: $space-3;
+  padding: $space-5 $space-7;
   border-radius: 1rem;
   background: var(--bs-body-bg);
   border: 1px solid var(--bs-border-color);
   box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
 }
 .kwg-conf-sponsor__label {
-  font-size: 0.74rem;
+  font-size: $text-xs;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -922,6 +954,106 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 .kwg-conf-sponsor img { max-width: 170px; width: 100%; height: auto; }
 
 @media (max-width: 480px) {
-  .kwg-conf-tl { grid-template-columns: 76px 24px 1fr; gap: 0 0.65rem; }
-  .kwg-conf-tl__time { font-size: 0.82rem; }
+  .kwg-conf-tl { grid-template-columns: 76px 24px 1fr; gap: 0 $space-3; }
+  .kwg-conf-tl__time { font-size: $text-sm; }
+}
+
+// ── Phase 1: 스크롤 등장 모션 (순수 CSS, 점진적 향상) ──────────────
+// prefers-reduced-motion 존중 + animation-timeline 미지원 브라우저는 정적 표시.
+// 첫 화면 히어로는 제외(로드 시 이미 보임), 스크롤로 드러나는 블록·카드만.
+@keyframes kwg-reveal-up {
+  from { opacity: 0; transform: translateY(18px); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: no-preference) {
+  @supports (animation-timeline: view()) {
+    .kwg-section__title,
+    .kwg-section__lead,
+    .kwg-feature,
+    .kwg-subcard,
+    .kwg-conf-speaker,
+    .kwg-conf-tl,
+    .kwg-conf-sponsor {
+      animation: kwg-reveal-up both linear;
+      animation-timeline: view();
+      animation-range: entry 0% entry 35%;
+    }
+  }
+}
+
+// ── Phase 5: 404 빈 상태 ─────────────────────────────────────
+.kwg-404 {
+  text-align: center;
+  padding: $space-10 $space-4;
+}
+.kwg-404__code {
+  font-size: 5rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  margin: 0 0 $space-4;
+  color: var(--bs-tertiary-color);
+}
+.kwg-404__title {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--bs-emphasis-color);
+  margin: 0 0 $space-3;
+}
+.kwg-404__desc {
+  font-size: $text-lg;
+  color: var(--bs-secondary-color);
+  margin: 0 0 $space-6;
+}
+.kwg-404__actions {
+  display: flex;
+  gap: $space-3;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.kwg-404__btn {
+  display: inline-block;
+  padding: $space-3 $space-6;
+  border-radius: 0.75rem;
+  font-weight: 500;
+  text-decoration: none;
+  background: linear-gradient(135deg, $primary, $secondary);
+  color: #fff;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.kwg-404__btn:hover {
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px rgba(2, 171, 184, 0.3);
+}
+.kwg-404__btn--ghost {
+  background: transparent;
+  color: var(--bs-body-color);
+  border: 1px solid var(--bs-border-color);
+}
+.kwg-404__btn--ghost:hover {
+  color: var(--bs-body-color);
+  background: var(--bs-tertiary-bg);
+  box-shadow: none;
+}
+
+// ── Phase 4: 다크 모드 보정 ──────────────────────────────────
+// 다크에선 그림자가 거의 안 보이므로, 카드를 살짝 밝은 면(tertiary-bg)으로 분리하고
+// 그림자를 끈다. hover 는 그림자 대신 accent 테두리로 반응. (미팅 컴포넌트 — 홈은 항상 다크라 무관)
+[data-bs-theme="dark"] {
+  .kwg-conf-hero,
+  .kwg-conf-hero__date,
+  .kwg-conf-speaker,
+  .kwg-conf-sponsor {
+    box-shadow: none;
+  }
+  .kwg-conf-hero__date,
+  .kwg-conf-speaker,
+  .kwg-conf-sponsor {
+    background: var(--bs-tertiary-bg);
+  }
+  .kwg-conf-speaker:hover {
+    box-shadow: none;
+    border-color: color-mix(in srgb, var(--accent, #ffd400) 35%, var(--bs-border-color));
+  }
 }

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -45,3 +45,27 @@ $box-shadow-lg: 0 8px 24px rgba(16, 24, 40, 0.1), 0 12px 40px rgba(16, 24, 40, 0
 // ── 본문 글자색: 순검정 대신 부드러운 진회색(Gemini식 가독성) ──
 // 다크 모드 글자색은 Bootstrap/Docsy 다크 보정이 자동 처리한다.
 $body-color: #2b2f33;
+
+// ── 간격 스케일(4/8pt 그리드) ────────────────────────────────
+// 컴포넌트 padding·margin·gap 은 이 토큰을 쓴다. 임의 rem 값 대신 정렬된 값으로.
+$space-1: 0.25rem; //  4
+$space-2: 0.5rem; //  8
+$space-3: 0.75rem; // 12
+$space-4: 1rem; // 16
+$space-5: 1.5rem; // 24
+$space-6: 2rem; // 32
+$space-7: 2.5rem; // 40
+$space-8: 3rem; // 48
+$space-9: 4rem; // 64
+$space-10: 6rem; // 96
+
+// ── 타입 스케일 ──────────────────────────────────────────────
+// font-size 는 이 토큰을 쓴다. (반응형이 필요한 큰 제목만 clamp 예외)
+$text-xs: 0.75rem; //   12
+$text-sm: 0.875rem; //  14
+$text-base: 1rem; //    16
+$text-lg: 1.125rem; //  18
+$text-xl: 1.25rem; //   20
+$text-2xl: 1.5rem; //   24
+$text-3xl: 2rem; //     32
+$text-4xl: 2.5rem; //   40

--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -124,19 +124,19 @@ aliases:
 
 <div class="kwg-conf-speakers">
   <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" src="heonkwan-ha.png" alt="Heonkwan Ha">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="heonkwan-ha.png" alt="Heonkwan Ha">
     <div class="kwg-conf-speaker__name">Heonkwan Ha, Manager</div>
     <div class="kwg-conf-speaker__role">KakaoBank · Session 1</div>
     <p class="kwg-conf-speaker__bio">Open source governance, DevSecOps, and CMDB operations at KakaoBank.</p>
   </div>
   <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" src="kangbo-kim.png" alt="Kangbo Kim">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="kangbo-kim.png" alt="Kangbo Kim">
     <div class="kwg-conf-speaker__name">Kangbo Kim, Team Lead</div>
     <div class="kwg-conf-speaker__role">AhnLab · Session 2</div>
     <p class="kwg-conf-speaker__bio">Team Lead of the Research Infrastructure Team at AhnLab. He designs and operates R&amp;D development-support environments — CI/CD infrastructure, OSS (Open Source Software) verification, static analysis, development-process standardization, build and signing, and patent and external-project management. His main focus is open source compliance and security-vulnerability response for security products, and building a static-analysis-centered CI/CD pipeline spanning development through release.</p>
   </div>
   <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" src="minae-lee.png" alt="Minae Lee">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="minae-lee.png" alt="Minae Lee">
     <div class="kwg-conf-speaker__name">Minae Lee, Manager</div>
     <div class="kwg-conf-speaker__role">KakaoBank · Session 3</div>
     <p class="kwg-conf-speaker__bio">Open source governance at KakaoBank, in-house IT policy, and internal/external audit response.</p>

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -125,19 +125,19 @@ aliases:
 
 <div class="kwg-conf-speakers">
   <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" src="heonkwan-ha.png" alt="하헌관 매니저">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="heonkwan-ha.png" alt="하헌관 매니저">
     <div class="kwg-conf-speaker__name">하헌관 매니저</div>
     <div class="kwg-conf-speaker__role">카카오뱅크 · Session 1</div>
     <p class="kwg-conf-speaker__bio">카카오뱅크 오픈소스 거버넌스, DevSecOps, CMDB 운영</p>
   </div>
   <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" src="kangbo-kim.png" alt="김강보 팀장">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="kangbo-kim.png" alt="김강보 팀장">
     <div class="kwg-conf-speaker__name">김강보 팀장</div>
     <div class="kwg-conf-speaker__role">안랩 · Session 2</div>
     <p class="kwg-conf-speaker__bio">안랩 연구인프라팀에서 팀장으로 근무하며, CI/CD 인프라 구축을 비롯해 OSS(Open Source Software) 검증, 정적 분석, 개발 프로세스 정립, 배포 및 서명, 특허와 외부 과제 관리 등 R&D 전반의 개발 지원 환경을 설계·운영하고 있습니다. 특히 보안 제품을 구성하는 오픈소스의 컴플라이언스 준수와 보안 취약점 대응, 그리고 정적 분석을 중심으로 한 개발부터 배포까지 이어지는 CI/CD 체계 구축을 주요 업무로 담당하고 있습니다.</p>
   </div>
   <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" src="minae-lee.png" alt="이민애 매니저">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="minae-lee.png" alt="이민애 매니저">
     <div class="kwg-conf-speaker__name">이민애 매니저</div>
     <div class="kwg-conf-speaker__role">카카오뱅크 · Session 3</div>
     <p class="kwg-conf-speaker__bio">카카오뱅크 오픈소스 거버넌스, 사내 IT 업무 관련 정책 담당, 내외부감사 대응</p>

--- a/docs/ui-ux-roadmap.md
+++ b/docs/ui-ux-roadmap.md
@@ -1,0 +1,50 @@
+# UI/UX 고도화 로드맵 — 글로벌 SaaS 수준 지향
+
+> OpenChain-KWG 사이트를 Linear·Stripe·Vercel·ai.google.dev 같은 상위 SaaS 수준의
+> "고급스러운 인상"으로 끌어올리기 위한 단계별 계획.
+
+## 원칙
+- "고급스러운 인상"의 8할은 **① 절제된 모션 ② 좋은 비주얼 1~2개 ③ 정밀한 여백**에서 나온다.
+- 우리는 제품 SaaS가 아니라 커뮤니티 문서 사이트 — 복잡한 인터랙션·백엔드 기능은 과투자.
+- 모든 모션은 `prefers-reduced-motion`을 존중(접근성).
+
+## 제약
+- **Docsy 모듈 유지**: 테마 레이아웃·SCSS 오버라이드는 최소화(업그레이드 회귀 위험). 현재 오버라이드: `navbar.html`, `meeting/baseof.html`, `hooks/head-end.html`.
+- **정적 사이트**(GitHub Pages): 백엔드 의존 기능 불가.
+- **JS는 허용**: `layouts/_partials/hooks/body-end.html`(Docsy 공식 훅) 또는 `assets/js/`+Hugo Pipes로 추가하면 업그레이드와 무관. (과거 "JS 쓰면 업그레이드 안 됨"은 오해였음.)
+
+## 단계 (권장 실행 순서)
+
+### Phase 1 — 모션·마이크로인터랙션 ⭐ [진행 중]
+가장 적은 비용으로 최대 체감 변화. 전 페이지 인상 향상.
+- 스크롤 등장: 순수 CSS `animation-timeline: view()` (섹션·카드·미팅 컴포넌트 fade/slide-in)
+- hover·focus 트랜지션 정교화
+- (옵션) `@view-transition` 페이지 전환
+- `prefers-reduced-motion` + `@supports` 가드 → 미지원/모션감소 시 정적(점진적 향상)
+
+### Phase 2 — 디자인 토큰 정밀화
+- spacing scale(4/8pt)을 변수로(`--space-*`)
+- 타입 스케일 일관화(흩어진 `rem`·`clamp` → 토큰)
+- `_variables_project.scss` 확장 → `.kwg-*` 치환
+
+### Phase 3 — 비주얼 에셋 업그레이드 (사용자 협업 필요)
+- 홈 히어로·핵심 섹션에 고품질 일러스트/3D 1~2개(AI PNG 제작 → 삽입)
+- 손코딩 SVG 5종 교체/보강, 아이콘 세트 통일
+
+### Phase 4 — 다크모드 일관성 + 컴포넌트 시스템
+- 라이트/다크 완전 대응 점검(홈 다크 고정 vs 문서 토글 정리)
+- `.kwg-*` + Docsy 기본을 토큰 기반 단일 시스템으로 통일
+
+### Phase 5 — 디테일·접근성·완성도
+- 404·빈 상태·검색 결과 페이지 다듬기
+- 접근성 audit(ARIA·키보드·WCAG AA 대비)
+- 성능(이미지 lazy-load, 폰트 최적화)
+
+## 진행 현황
+- [x] Phase 1 — 모션 (CSS `animation-timeline` 스크롤 등장, 미배포)
+- [x] Phase 2 — 토큰 (spacing/type scale 정의 + 미팅·홈 전면 적용, 미배포)
+- [~] Phase 3 — 에셋: CSS 추상 비주얼(홈 메시 그라데이션) + 아이콘 통일(FA→인라인 SVG) 완료. **회화적 일러스트/3D PNG만 협업 잔여**.
+- [~] Phase 5 — 접근성·디테일: 404 다국어+브랜드 빈상태, 발표자 사진 lazy-load, 폰트 swap 확인 완료. **색대비/스크린리더 정밀 audit(Lighthouse 등)는 도구 필요**.
+- [~] Phase 4 — 다크·컴포넌트: 다크 모드 보정(그림자→면/테두리 구분) 완료. 홈 다크 고정은 의도된 패턴이라 유지, 컴포넌트는 맥락 차이로 억지 통일 안 함.
+
+각 Phase는 독립 PR로 점진 배포한다.

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,7 +1,12 @@
 {{ define "main" -}}
-<div class="td-content">
-  <h1>Not found</h1>
-  <p>Oops! This page doesn't exist. Try going back to the <a href="{{ "" | relURL }}">home page</a>.</p>
-  <p>You can learn how to make a 404 page like this in <a href="https://gohugo.io/templates/404/">Custom 404 Pages</a>.</p>
+{{ $ko := eq .Site.Language.Lang "ko" -}}
+<div class="td-content kwg-404">
+  <p class="kwg-404__code" aria-hidden="true">404</p>
+  <h1 class="kwg-404__title">{{ if $ko }}페이지를 찾을 수 없습니다{{ else }}Page not found{{ end }}</h1>
+  <p class="kwg-404__desc">{{ if $ko }}요청하신 페이지가 없거나 다른 곳으로 옮겨졌습니다.{{ else }}The page you're looking for doesn't exist or has moved.{{ end }}</p>
+  <div class="kwg-404__actions">
+    <a class="kwg-404__btn" href="{{ "" | relLangURL }}">{{ if $ko }}홈으로{{ else }}Back to home{{ end }}</a>
+    <a class="kwg-404__btn kwg-404__btn--ghost" href="{{ "meeting/" | relLangURL }}">{{ if $ko }}정기 미팅 보기{{ else }}Meetings{{ end }}</a>
+  </div>
 </div>
 {{- end }}

--- a/layouts/_partials/icon-arrow.html
+++ b/layouts/_partials/icon-arrow.html
@@ -1,0 +1,2 @@
+{{- /* 일관된 stroke 화살표 아이콘(Lucide arrow-right). Font Awesome 대체. 크기·여백은 .kwg-icon */ -}}
+<svg class="kwg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,14 +13,14 @@
   {{ with .Resources.GetMatch "featured-background.jpg" }}{{ $bg = (.Resize "2048x webp q80").RelPermalink }}{{ end }}
   <section class="kwg-hero"{{ with $bg }} style="background-image: linear-gradient(180deg, rgba(6,20,27,0.92) 0%, rgba(6,20,27,0.6) 34%, rgba(6,20,27,0.35) 58%, rgba(6,20,27,0.6) 100%), url('{{ . }}')"{{ end }}>
     <div class="container kwg-hero__inner">
-      <span class="kwg-hero__badge">Linux Foundation · OpenChain Project</span>
+      <a class="kwg-hero__badge" href="https://openchainproject.org/" target="_blank" rel="noopener">Linux Foundation · OpenChain Project</a>
       <h1 class="kwg-hero__title">OpenChain Korea<br>Work Group</h1>
       <p class="kwg-hero__sub">
         {{ if $ko }}한국 기업의 오픈소스 컴플라이언스 담당자들이 모여 지식과 경험을 나누는 커뮤니티입니다.{{ else }}A community where open source compliance practitioners at Korean companies share knowledge and experience.{{ end }}
       </p>
       <div class="kwg-hero__cta">
-        <a class="btn btn-lg btn-primary" href="{{ "about/" | relLangURL }}">{{ if $ko }}소개 보기{{ else }}About{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></a>
-        <a class="btn btn-lg btn-outline-primary" href="https://discord.com/channels/1177116701561729104/" target="_blank" rel="noopener">Discord</a>
+        <a class="btn btn-lg btn-primary" href="{{ "about/" | relLangURL }}">{{ if $ko }}소개 보기{{ else }}About{{ end }} {{ partial "icon-arrow.html" . }}</a>
+        <a class="btn btn-lg btn-outline-primary" href="{{ "about/subscribe/" | relLangURL }}">{{ if $ko }}메일링리스트 가입{{ else }}Join the mailing list{{ end }}</a>
       </div>
     </div>
   </section>
@@ -46,7 +46,7 @@
               <span class="kwg-stats__label">{{ if $ko }}함께한 시작{{ else }}Since{{ end }}</span>
             </div>
           </div>
-          <a class="kwg-btn-pill" href="{{ "about/" | relLangURL }}">{{ if $ko }}참여 방법 보기{{ else }}How to join{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></a>
+          <a class="kwg-btn-pill" href="{{ "about/" | relLangURL }}">{{ if $ko }}참여 방법 보기{{ else }}How to join{{ end }} {{ partial "icon-arrow.html" . }}</a>
         </div>
         <div class="kwg-feature__visual" aria-hidden="true">
           <img class="kwg-tabs__art" src="{{ "images/kwg-viz-community.svg" | relURL }}" alt="">
@@ -58,21 +58,21 @@
           <div class="kwg-subcard__body">
             <h3 class="kwg-subcard__title">{{ if $ko }}정기 미팅{{ else }}Meetings{{ end }}</h3>
             <p class="kwg-subcard__desc">{{ if $ko }}정기 미팅에서 기업들의 사례와 인사이트를 공유합니다.{{ else }}Regular meetings to share company cases and insights.{{ end }}</p>
-            <span class="kwg-subcard__link">{{ if $ko }}일정 보기{{ else }}Schedule{{ end }} <i class="fa-solid fa-arrow-right"></i></span>
+            <span class="kwg-subcard__link">{{ if $ko }}일정 보기{{ else }}Schedule{{ end }} {{ partial "icon-arrow.html" . }}</span>
           </div>
         </a>
         <a class="kwg-subcard" href="{{ "about/subscribe/" | relLangURL }}">
           <div class="kwg-subcard__body">
             <h3 class="kwg-subcard__title">{{ if $ko }}메일링 리스트{{ else }}Mailing List{{ end }}</h3>
             <p class="kwg-subcard__desc">{{ if $ko }}오픈소스 컴플라이언스 담당자라면 누구나 참여할 수 있습니다.{{ else }}Open to anyone working on OSS compliance.{{ end }}</p>
-            <span class="kwg-subcard__link">{{ if $ko }}가입하기{{ else }}Subscribe{{ end }} <i class="fa-solid fa-arrow-right"></i></span>
+            <span class="kwg-subcard__link">{{ if $ko }}가입하기{{ else }}Subscribe{{ end }} {{ partial "icon-arrow.html" . }}</span>
           </div>
         </a>
         <a class="kwg-subcard" href="https://discord.com/channels/1177116701561729104/" target="_blank" rel="noopener">
           <div class="kwg-subcard__body">
             <h3 class="kwg-subcard__title">Discord</h3>
             <p class="kwg-subcard__desc">{{ if $ko }}가벼운 대화와 멤버 간 실시간 소통 공간.{{ else }}Casual, real-time conversation among members.{{ end }}</p>
-            <span class="kwg-subcard__link">{{ if $ko }}참여하기{{ else }}Join{{ end }} <i class="fa-solid fa-arrow-right"></i></span>
+            <span class="kwg-subcard__link">{{ if $ko }}참여하기{{ else }}Join{{ end }} {{ partial "icon-arrow.html" . }}</span>
           </div>
         </a>
       </div>
@@ -101,7 +101,7 @@
         <div class="kwg-feature__text">
           <h3 class="kwg-feature__title">{{ if $ko }}2026 기업 오픈소스 관리 가이드{{ else }}Enterprise OSS Management Guide{{ end }}</h3>
           <p class="kwg-feature__desc">{{ if $ko }}ISO 국제표준에 기반해 기업이 오픈소스를 도입·관리·배포하는 전 과정을 조직·정책·프로세스 관점에서 단계별로 안내합니다.{{ else }}A step-by-step guide to adopting, managing, and distributing open source across organization, policy, and process — grounded in ISO standards.{{ end }}</p>
-          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></span>
+          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} {{ partial "icon-arrow.html" . }}</span>
         </div>
         <div class="kwg-tabs__visual" aria-hidden="true">
           <img class="kwg-tabs__art" src="{{ "images/kwg-tab-visual.svg" | relURL }}" alt="">
@@ -112,7 +112,7 @@
         <div class="kwg-feature__text">
           <h3 class="kwg-feature__title">ISO/IEC 5230</h3>
           <p class="kwg-feature__desc">{{ if $ko }}오픈소스 라이선스 컴플라이언스 국제표준(OpenChain). 25개 입증자료 항목을 조항별로 풀어 실무 적용을 돕습니다.{{ else }}The international standard for open source license compliance (OpenChain). We break down all 25 evidence items clause by clause.{{ end }}</p>
-          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></span>
+          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} {{ partial "icon-arrow.html" . }}</span>
         </div>
         <div class="kwg-tabs__visual" aria-hidden="true">
           <img class="kwg-tabs__art" src="{{ "images/kwg-viz-license.svg" | relURL }}" alt="">
@@ -123,7 +123,7 @@
         <div class="kwg-feature__text">
           <h3 class="kwg-feature__title">ISO/IEC 18974</h3>
           <p class="kwg-feature__desc">{{ if $ko }}오픈소스 보안 보증(OSS Security Assurance) 국제표준. 보안 취약점 대응 체계를 조항별 입증자료로 안내합니다.{{ else }}The international standard for open source security assurance, guiding vulnerability response with clause-level evidence.{{ end }}</p>
-          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></span>
+          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} {{ partial "icon-arrow.html" . }}</span>
         </div>
         <div class="kwg-tabs__visual" aria-hidden="true">
           <img class="kwg-tabs__art" src="{{ "images/kwg-viz-security.svg" | relURL }}" alt="">
@@ -134,7 +134,7 @@
         <div class="kwg-feature__text">
           <h3 class="kwg-feature__title">ISO/IEC 42001</h3>
           <p class="kwg-feature__desc">{{ if $ko }}AI 관리 시스템(AIMS) 국제표준을 오픈소스 관점에서 풀어, AI 시스템 개발·운영의 핵심 요구사항을 다룹니다.{{ else }}The AI management system (AIMS) standard from an open source perspective, covering key requirements for AI development and operations.{{ end }}</p>
-          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} <i class="fa-solid fa-arrow-right ms-1"></i></span>
+          <span class="kwg-btn-pill">{{ if $ko }}가이드 보기{{ else }}View guide{{ end }} {{ partial "icon-arrow.html" . }}</span>
         </div>
         <div class="kwg-tabs__visual" aria-hidden="true">
           <img class="kwg-tabs__art" src="{{ "images/kwg-viz-ai.svg" | relURL }}" alt="">


### PR DESCRIPTION
글로벌 SaaS 수준 UI/UX 로드맵의 단독 가능 작업 일괄.

## Phase 1~5
- **모션**: CSS `animation-timeline` 스크롤 등장(prefers-reduced-motion 가드)
- **토큰**: spacing/type scale 정의 + 미팅·홈 전면 적용(디스플레이 폰트·큰 여백은 예외)
- **추상 비주얼**: 홈 다크 배경 메시 그라데이션
- **아이콘**: 화살표 Font Awesome→인라인 SVG 통일
- **다크 보정**: 그림자 대신 면/테두리로 카드 구분
- **404**: 다국어·브랜드 빈상태, 발표자 사진 lazy-load

## 홈 히어로
- 배지를 OpenChain 공식 사이트 링크로
- 보조 CTA Discord→메일링리스트 가입

## 잔여(별도)
- 회화 일러스트/3D PNG(AI 제작 협업), 색대비·스크린리더 정밀 audit(Lighthouse)

로드맵: `docs/ui-ux-roadmap.md`. hugo --minify 빌드 정상.