### PR TITLE
feat(meeting): 30회 OpenChain Updates 발표자료 PDF 링크 추가

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -868,6 +868,13 @@ a.kwg-hero__badge:hover {
   color: var(--bs-secondary-color);
   margin-top: $space-1;
 }
+.kwg-conf-tl__slide {
+  display: inline-block;
+  margin-top: $space-2;
+  font-size: $text-sm;
+  font-weight: 600;
+}
+.kwg-conf-tl__slide:hover { text-decoration: underline; }
 // 세션 강조 — 채운 accent 노드(약간 크게)
 .kwg-conf-tl--session .kwg-conf-tl__marker::after {
   width: 13px;

--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -68,6 +68,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">OpenChain Updates</div>
       <div class="kwg-conf-tl__by">Steering Committee</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-kwg-update-2026q2.pdf" target="_blank" rel="noopener">Slides (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -69,6 +69,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">OpenChain Updates</div>
       <div class="kwg-conf-tl__by">운영진</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-kwg-update-2026q2.pdf" target="_blank" rel="noopener">발표자료 (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">


### PR DESCRIPTION
## 변경 내용

30회 미팅 페이지 아젠다의 OpenChain Updates 행에 발표자료(PDF) 링크를 추가했습니다.

- PDF는 관례대로 `meeting-slides-2026` GitHub Release에 업로드
- 링크 위치: 랜딩 레이아웃 타임라인의 OpenChain Updates 항목 (29회 Slide 컬럼과 동일한 개념)
- ko/en 양쪽 동기화 (`발표자료 (PDF)` / `Slides (PDF)`)
- `.kwg-conf-tl__slide` 링크 스타일 추가

## 검증

- `hugo --minify` 빌드 성공
- 생성 HTML(ko/en)·CSS에 링크·스타일 반영 확인
- 릴리스 PDF URL HTTP 200