### PR TITLE
feat(meeting): 30회 그룹토의 조 편성·토의 주제 PDF 링크 추가

### DIFF
--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -109,6 +109,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">Group Discussion</div>
       <div class="kwg-conf-tl__by">All Participants</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-group-discussion.pdf" target="_blank" rel="noopener">Groups &amp; Topics (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl">

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -110,6 +110,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">그룹 토의</div>
       <div class="kwg-conf-tl__by">All Participants</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-group-discussion.pdf" target="_blank" rel="noopener">조 편성·토의 주제 (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl">


### PR DESCRIPTION
## 변경 내용

30회 미팅 페이지 아젠다의 그룹 토의 행에 조 편성·토의 주제 PDF 다운로드 링크를 추가했습니다.

- PDF는 `meeting-slides-2026` GitHub Release에 업로드
- 링크 위치: 랜딩 레이아웃 타임라인의 그룹 토의 항목
- ko/en 양쪽 동기화 (`조 편성·토의 주제 (PDF)` / `Groups & Topics (PDF)`)

## 검증

- `hugo --minify` 빌드 성공
- 생성 HTML(ko/en)에 링크 반영, 릴리스 PDF URL HTTP 200