### PR TITLE
meeting: 30회차 미팅 페이지에 Flickr 앨범 추가

### DIFF
--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -151,3 +151,7 @@ aliases:
   <span class="kwg-conf-sponsor__label">Sponsored by</span>
   <img src="../../../../images/content/about/logo/kakaobank.png" alt="KakaoBank">
 </div>
+
+## Album
+
+<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/72177720334110321" title="[2026 June] OpenChain Korea Work Group in Kakao Bank"><img src="https://live.staticflickr.com/65535/55324287806_9c07d82ddc_h.jpg" width="1600" height="1200" alt="[2026 June] OpenChain Korea Work Group in Kakao Bank"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -152,3 +152,7 @@ aliases:
   <span class="kwg-conf-sponsor__label">이번 미팅 후원</span>
   <img src="../../../images/content/about/logo/kakaobank.png" alt="KakaoBank">
 </div>
+
+## Album
+
+<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/72177720334110321" title="[2026 June] OpenChain Korea Work Group in Kakao Bank"><img src="https://live.staticflickr.com/65535/55324287806_9c07d82ddc_h.jpg" width="1600" height="1200" alt="[2026 June] OpenChain Korea Work Group in Kakao Bank"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>


### PR DESCRIPTION
30회차(2026년 6월 카카오뱅크) 미팅 종료 후 Flickr 사진 앨범을 추가합니다.

- ko/en 양쪽 `content/.../2026/30th/_index.md` Sponsor 섹션 뒤에 `## Album` 추가
- 앨범: [2026 June] OpenChain Korea Work Group in Kakao Bank
- 기존 미팅과 동일한 Flickr 임베드 방식 유지