### PR TITLE
meeting(30th): OpenChain Updates 글로벌 동향 반영 + Mary Wang 발표자료 링크

### DIFF
--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -67,8 +67,9 @@ aliases:
     <div class="kwg-conf-tl__marker"></div>
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">OpenChain Updates</div>
-      <div class="kwg-conf-tl__by">Steering Committee</div>
-      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-kwg-update-2026q2.pdf" target="_blank" rel="noopener">Slides (PDF)</a>
+      <div class="kwg-conf-tl__by">Steering Committee · Mary Wang (Executive Director, OpenChain Project — remote)</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-kwg-update-2026q2.pdf" target="_blank" rel="noopener">KWG Update (PDF)</a>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-openchain-updates.pdf" target="_blank" rel="noopener">OpenChain Global Update · Mary Wang (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">
@@ -121,6 +122,30 @@ aliases:
     </div>
   </div>
 </div>
+
+## OpenChain Updates: Global Highlights
+
+During the OpenChain Updates segment, Mary Wang, Executive Director of the OpenChain Project, joined remotely to share global highlights. Alongside the current status of the standards, she positioned OpenChain as a key foundation linking compliance with the EU Cyber Resilience Act (CRA) and AI regulation.
+
+### Standards and Community Status
+
+OpenChain maintains two international standards, ISO 5230 and ISO 18974, adopted by more than 100 companies worldwide. It runs a 25-member governance board, and in 2026 Renesas joined as a new board member. The OpenChain China Work Group is set to launch, and new partners including OSCHINA have joined.
+
+### ISO 5230 Revision Status
+
+Under ISO rules, every standard must be renewed every five years. Five years on from ISO 5230:2020, the standard has been officially renewed without any change. Separately, the latest version reflecting minor modifications made over the past three years is 3.0; at the Q2 board meeting, the project decided to formally submit these to ISO. The designation 5230 will be retained, with a revision label applied only if necessary.
+
+### Next Chapter: CRA
+
+The EU Cyber Resilience Act (CRA) requires four things of companies selling software in the EU: Secure by Design, transparency over all open source components, continuous vulnerability management, and rapid reporting of security incidents. To respond, OpenChain formed a Business Operation Work Group, whose current topic is CRA. It is researching CRA-compliance gaps across organizations and identifying how OpenChain can support them.
+
+### Next Chapter: AI Governance
+
+OpenChain is also expanding into AI. It addresses the EU AI Act, integrates with ISO 42001, 42002, and 42003, and runs the OpenChain AI Work Group. The OpenChain AI SBOM Self Certification is also under way.
+
+### Also Worth Noting
+
+An OpenChain introduction video is planned for OCS (Open Compliance Summit) in December, and the "Adopt our standards" webpage has been updated. The OpenChain and Friends webinar series is ongoing. Organizations looking to adopt the standards can refer to the [OpenChain get-started page](https://openchainproject.org/get-started).
 
 ## Speakers
 

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -68,8 +68,9 @@ aliases:
     <div class="kwg-conf-tl__marker"></div>
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">OpenChain Updates</div>
-      <div class="kwg-conf-tl__by">운영진</div>
-      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-kwg-update-2026q2.pdf" target="_blank" rel="noopener">발표자료 (PDF)</a>
+      <div class="kwg-conf-tl__by">운영진 · Mary Wang (OpenChain Project 총괄 디렉터, 원격)</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-kwg-update-2026q2.pdf" target="_blank" rel="noopener">KWG 업데이트 (PDF)</a>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-openchain-updates.pdf" target="_blank" rel="noopener">OpenChain 글로벌 업데이트 · Mary Wang (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">
@@ -122,6 +123,30 @@ aliases:
     </div>
   </div>
 </div>
+
+## OpenChain Updates: 글로벌 동향
+
+OpenChain Updates 시간에는 OpenChain Project 총괄 디렉터 Mary Wang이 원격으로 참여해 글로벌 동향을 공유했습니다. 표준 운영 현황과 함께, OpenChain을 CRA(EU 사이버 복원력법)와 AI 규제 대응을 연결하는 핵심 기반으로 설명했습니다.
+
+### 표준과 커뮤니티 현황
+
+ISO 5230과 ISO 18974 두 국제표준을 운영하며 전 세계 100여 개 기업이 채택했습니다. 25인 거버넌스 보드를 두고 있고, 2026년에는 Renesas가 신규 보드 멤버로 합류했습니다. OpenChain China Work Group 출범이 예정돼 있으며, OSCHINA를 포함한 신규 파트너도 합류했습니다.
+
+### ISO 5230 개정 현황
+
+ISO 규정상 모든 표준은 5년마다 갱신해야 합니다. ISO 5230:2020이 5년을 지나 내용 변경 없이 공식 갱신됐습니다. 한편 지난 3년간 반영한 소규모 수정사항을 담은 최신본은 3.0이며, 2분기 보드 회의에서 이를 ISO에 공식 제출하기로 결정했습니다. 표준 명칭은 5230을 그대로 유지하고, 필요한 경우에만 개정 라벨을 붙이기로 했습니다.
+
+### 다음 과제: CRA 대응
+
+EU 사이버 복원력법(CRA, Cyber Resilience Act)은 EU에 소프트웨어를 판매하는 기업에 네 가지를 요구합니다. 설계 단계부터의 보안(Secure by Design), 모든 오픈소스 구성요소에 대한 투명성, 지속적인 취약점 관리, 보안 사고의 신속한 보고입니다. OpenChain은 이에 대응하기 위해 Business Operation Work Group을 신설했고, 현재 주제가 CRA입니다. 조직별 CRA 준수 격차를 조사하고 OpenChain이 지원할 수 있는 방안을 찾고 있습니다.
+
+### 다음 과제: AI 거버넌스
+
+AI 영역으로도 범위를 넓히고 있습니다. EU AI Act에 대응하고 ISO 42001, 42002, 42003과 연계하며 OpenChain AI Work Group을 운영합니다. OpenChain AI SBOM 자가 인증(Self Certification)도 추진하고 있습니다.
+
+### 그 밖의 소식
+
+12월 OCS(Open Compliance Summit)에서 OpenChain 소개 영상을 제작할 예정이며, 'Adopt our standards' 웹페이지를 개편했습니다. OpenChain and Friends 웨비나도 진행 중입니다. 표준 채택을 시작하려는 조직은 [OpenChain 안내 페이지](https://openchainproject.org/get-started)를 참고하시기 바랍니다.
 
 ## 발표자 소개
 


### PR DESCRIPTION
## 개요

30차 모임 OpenChain Updates 시간에 OpenChain Project 총괄 디렉터 Mary Wang이 원격으로 발표한 글로벌 동향을 30차 미팅 페이지에 반영합니다.

## 변경 내용

- 아젠다 OpenChain Updates 항목 발표자 표기에 Mary Wang(원격) 추가
- `OpenChain Updates: 글로벌 동향` 요약 섹션 신설
  - 표준·커뮤니티 현황(ISO 5230/18974, 100여 개사 채택, 25인 보드, Renesas 합류, China WG)
  - ISO 5230 개정 현황(5년 주기 갱신, 최신본 3.0 ISO 제출 결정)
  - 다음 과제: CRA 대응 / AI 거버넌스
  - 그 밖의 소식(OCS 영상, 웹페이지 개편, Friends 웨비나)
- 슬라이드 링크를 KWG 업데이트 / OpenChain 글로벌 업데이트(Mary Wang) 2종으로 분리
- ko/en 동기화

## 발표자료

Mary Wang 발표자료는 `meeting-slides-2026` 릴리스에 `30th-openchain-updates.pdf`로 업로드 완료(저장소 미커밋, CLAUDE.md 규칙 준수).

## 검증

- `hugo --minify` 빌드 성공
- `.claude/gate.sh` 통과
- ko-style 린트 0건