### PR TITLE
style: 본문·alert 박스의 80% 폭 제한 해제로 pageinfo와 폭 통일

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -180,6 +180,31 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
   border-radius: $border-radius;
 }
 
+// 본문 줄 길이 80% 제한 해제 — pageinfo와 폭 통일
+// (Docsy _content.scss가 .td-content 직계 자식에 거는 .td-max-width-on-larger-screens 무효화.
+//  유틸리티 클래스 자체는 tabbed-pane 등 다른 쇼트코드가 쓰므로 건드리지 않고,
+//  같은 선택자 목록을 미러링해 동일 특이도로 뒤에서 덮는다)
+@include media-breakpoint-up(lg) {
+  .td-content {
+    .footnotes,
+    > .alert,
+    > .highlight,
+    > .katex-display,
+    > .lead,
+    > .td-table,
+    > blockquote,
+    > dl dd,
+    > h1,
+    > h2,
+    > ol,
+    > p,
+    > pre,
+    > ul {
+      max-width: none;
+    }
+  }
+}
+
 // 문서 내 primary 버튼 — 홈 pill·lift 톤과 통일
 .td-content .btn-primary {
   border-radius: 2rem;


### PR DESCRIPTION
## 배경

문서 페이지에서 `pageinfo` 박스는 본문 영역 풀폭인데, `alert` 박스와 본문 문단은 오른쪽이 일찍 끝나 폭이 어긋나 보입니다.

원인은 Docsy가 `.td-content` 직계 자식(`> p`, `> .alert`, `> ul` 등)에 큰 화면(lg 이상)에서 `max-width: 80%`를 적용하는 줄 길이 제한입니다. `.pageinfo`는 이 목록에 없어 풀폭이라 차이가 생깁니다.

## 변경

`assets/scss/_styles_project.scss`에 Docsy의 해당 선택자 목록을 미러링해 같은 특이도로 `max-width: none`을 덮습니다. 유틸리티 클래스(`.td-max-width-on-larger-screens`) 자체는 tabbed-pane 등 다른 쇼트코드가 쓰므로 건드리지 않았습니다.

폰트 크기는 뷰포트 기준이라 변하지 않고, 줄 길이만 본문 영역 폭에 맞게 늘어납니다. 사이트 전체 문서 페이지에 적용됩니다.

## 검증

- `hugo --minify` 빌드 성공, 컴파일된 CSS에서 오버라이드가 80% 규칙 뒤에 위치(동일 특이도, 캐스케이드로 적용)함을 확인.
- `.claude/gate.sh` 통과.