### PR TITLE
fix(meeting): 아젠다 슬라이드 링크 줄바꿈 구분

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -894,10 +894,15 @@ a.kwg-hero__badge:hover {
   margin-top: $space-1;
 }
 .kwg-conf-tl__slide {
-  display: inline-block;
+  display: block;
+  width: fit-content;
   margin-top: $space-2;
   font-size: $text-sm;
   font-weight: 600;
+}
+.kwg-conf-tl__slide::before {
+  content: "\2193\00a0"; // 다운로드 화살표 + 공백
+  opacity: 0.7;
 }
 .kwg-conf-tl__slide:hover { text-decoration: underline; }
 // 세션 강조 — 채운 accent 노드(약간 크게)


### PR DESCRIPTION
## 문제

발표자료 링크가 두 개 이상일 때 `.kwg-conf-tl__slide`가 `inline-block`이라 한 줄에 붙어 별개 PDF인지 구분이 어려움(30차 OpenChain Updates).

## 수정

- `display: block; width: fit-content;` 로 링크마다 줄 분리
- 앞에 다운로드 화살표(↓)를 붙여 PDF 다운로드 항목임을 명확히 표시

단일 링크인 다른 미팅에는 줄바꿈 영향 없이 화살표만 추가됨.

## 검증

`hugo --minify` 빌드 성공.