### PR TITLE
meeting(30th): 세션 1~3 발표자료 PDF 링크 추가

### DIFF
--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -78,6 +78,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">Session 1. AI-driven Open Source Governance</div>
       <div class="kwg-conf-tl__by">Heonkwan Ha · KakaoBank</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-session1-ai-driven-oss-governance.pdf" target="_blank" rel="noopener">Slides (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--muted">
@@ -94,6 +95,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">Session 2. The Impact of Claude Mythos on Open Source</div>
       <div class="kwg-conf-tl__by">Kangbo Kim · AhnLab</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-session2-claude-mythos.pdf" target="_blank" rel="noopener">Slides (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">
@@ -102,6 +104,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">Session 3. Experience Report on Open Source Operations as a Financial Company</div>
       <div class="kwg-conf-tl__by">Minae Lee · KakaoBank</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-session3-finance-oss-report.pdf" target="_blank" rel="noopener">Slides (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl">

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -79,6 +79,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">Session 1. AI-driven Open Source Governance</div>
       <div class="kwg-conf-tl__by">하헌관 · 카카오뱅크</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-session1-ai-driven-oss-governance.pdf" target="_blank" rel="noopener">발표자료 (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--muted">
@@ -95,6 +96,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">Session 2. Claude Mythos가 Open Source에 미치는 영향</div>
       <div class="kwg-conf-tl__by">김강보 · 안랩</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-session2-claude-mythos.pdf" target="_blank" rel="noopener">발표자료 (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">
@@ -103,6 +105,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">Session 3. 금융회사로서의 오픈소스 관련 업무 대응 후기</div>
       <div class="kwg-conf-tl__by">이민애 · 카카오뱅크</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/30th-session3-finance-oss-report.pdf" target="_blank" rel="noopener">발표자료 (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl">


### PR DESCRIPTION
## 개요

30차 모임 세 세션 발표자료를 `meeting-slides-2026` 릴리스에 업로드하고, 아젠다 Session 1~3에 발표자료(PDF) 링크를 추가합니다.

## 업로드 자산

- Session 1 (하헌관, AI-driven Open Source Governance) → `30th-session1-ai-driven-oss-governance.pdf`
- Session 2 (김강보, Claude Mythos) → `30th-session2-claude-mythos.pdf`
- Session 3 (이민애, 오픈소스 대응 후기) → `30th-session3-finance-oss-report.pdf`

저장소 미커밋, 릴리스 게시(HTTP 200 확인). CLAUDE.md 발표자료 정책 준수.

## 검증

- `hugo --minify` 빌드 성공
- `.claude/gate.sh` 통과
- ko/en 동기화