### PR TITLE
meeting(31th): 30차 수준 컨퍼런스 랜딩 레이아웃으로 개선

### DIFF
--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -1,24 +1,62 @@
 ---
 title: "31th Meeting"
 linkTitle: "31th · 2026.09 CJ"
-date: 2026-03-31T17:23:41+09:00
 weight: 31
-type: docs
+type: meeting
+layout: landing
 categories: ["meeting"]
 tags: ["OpenChain"]
 description: >
   September 8, 2026 (Tue) / CJ
-draft: false
+aliases:
+  - /en/meeting/31th/
 ---
 
-## Schedule
+<style>
+/* Per-meeting sponsor color — for the next meeting, change just these two values. */
+.td-content { --accent: #e30613; --ink: #fff5f3; }
+</style>
 
-* Schedule: 2026-09-08 (Tue) 2:00 PM ~ 5:00 PM
-* Venue: CJ Human Resources Development Center (Jung-gu, Seoul - https://maps.app.goo.gl/nQUogVHPvF4VuapX9 )
+<div class="kwg-conf-hero">
+  <div class="kwg-conf-hero__body">
+    <p class="kwg-conf-hero__eyebrow">31st Meeting</p>
+    <h1 class="kwg-conf-hero__title">OpenChain KWG 31st Meeting</h1>
+    <p class="kwg-conf-hero__sub">We are preparing the autumn 2026 meeting together with CJ. The detailed program will be announced on this page and via the mailing list once confirmed.</p>
+    <div class="kwg-conf-hero__meta">
+      <span><strong>Date</strong> 2026-09-08 (Tue) 14:00–17:00</span>
+      <span><strong>Venue</strong> CJ Human Resources Development Center · Jung-gu, Seoul</span>
+    </div>
+    <p class="kwg-conf-hero__note">Registration and the detailed program are announced via the OpenChain KWG mailing list. Subscribe to receive the sign-up link.</p>
+    <div class="kwg-conf-hero__cta">
+      <a class="kwg-conf-cta" href="../../../about/subscribe/">Join the mailing list</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://maps.app.goo.gl/nQUogVHPvF4VuapX9" target="_blank" rel="noopener">Open in Google Maps</a>
+    </div>
+  </div>
+  <div class="kwg-conf-hero__date">
+    <span class="kwg-conf-hero__date-d">08</span>
+    <span class="kwg-conf-hero__date-my">Sep 2026 · Tue</span>
+  </div>
+</div>
 
+<ul class="kwg-conf-chips">
+  <li class="kwg-conf-chip">OpenChain</li>
+  <li class="kwg-conf-chip">OSS Compliance</li>
+  <li class="kwg-conf-chip">Korea Work Group</li>
+</ul>
 
+## Who Should Attend
+
+- Practitioners running or newly introducing open source compliance policies at their company
+- Organizations working through OpenChain (ISO 5230), SBOM, and security-vulnerability response
+- Anyone who wants to hear other companies' cases and expand their practitioner network
+
+## Agenda
+
+> The detailed program is in preparation. It will be published on this page and announced via the mailing list once confirmed. If you have a topic you would like to present or discuss, please propose it through the mailing list.
 
 ## Sponsor
 
-![](../../../../images/content/about/logo/cj.png)
-
+<div class="kwg-conf-sponsor">
+  <span class="kwg-conf-sponsor__label">Sponsored by</span>
+  <img src="../../../../images/content/about/logo/cj.png" alt="CJ">
+</div>

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -1,55 +1,63 @@
 ---
 title: "31th Meeting"
 linkTitle: "31th · 2026.09 CJ"
-date: 2026-03-31T17:19:04+09:00
 weight: 31
-type: docs
+type: meeting
+layout: landing
 categories: ["meeting"]
 tags: ["OpenChain"]
 description: >
   2026년 9월 8일 (화) / CJ
-draft: false
+aliases:
+  - /meeting/31th/
 ---
 
-## 일정
+<style>
+/* 회차별 스폰서 색 — 다음 회차는 이 두 값만 그 스폰서 색으로 교체. */
+.td-content { --accent: #e30613; --ink: #fff5f3; }
+</style>
 
-* 일정: 2026-09-08 (화) 오후 2시~5시
-* 장소: CJ인재원 (서울시 중구 - https://maps.app.goo.gl/nQUogVHPvF4VuapX9 )
+<div class="kwg-conf-hero">
+  <div class="kwg-conf-hero__body">
+    <p class="kwg-conf-hero__eyebrow">31st Meeting</p>
+    <h1 class="kwg-conf-hero__title">OpenChain KWG 31차 정기 모임</h1>
+    <p class="kwg-conf-hero__sub">2026년 가을 정기 모임을 CJ와 함께 준비하고 있습니다. 세부 프로그램은 확정되는 대로 이 페이지와 메일링리스트로 안내드립니다.</p>
+    <div class="kwg-conf-hero__meta">
+      <span><strong>일시</strong> 2026-09-08 (화) 14:00–17:00</span>
+      <span><strong>장소</strong> CJ인재원 · 서울 중구</span>
+    </div>
+    <p class="kwg-conf-hero__note">참가 신청과 세부 프로그램은 OpenChain KWG 메일링리스트로 안내됩니다. 가입하시면 신청 링크를 받아보실 수 있습니다.</p>
+    <div class="kwg-conf-hero__cta">
+      <a class="kwg-conf-cta" href="../../../about/subscribe/">메일링리스트 가입</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.naver.com/p/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">네이버지도</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.kakao.com/link/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">카카오맵</a>
+    </div>
+  </div>
+  <div class="kwg-conf-hero__date">
+    <span class="kwg-conf-hero__date-d">08</span>
+    <span class="kwg-conf-hero__date-my">2026년 9월 · 화</span>
+  </div>
+</div>
 
-<!-- ## 아젠다
+<ul class="kwg-conf-chips">
+  <li class="kwg-conf-chip">OpenChain</li>
+  <li class="kwg-conf-chip">OSS Compliance</li>
+  <li class="kwg-conf-chip">Korea Work Group</li>
+</ul>
 
-| Time        | Agenda                        | Speaker                          | Slide |
-|-------------|-------------------------------|----------------------------------|-------|
-| 00:00~00:00 | 웰컴 & 오프닝                 | 발표자, 소속                      | -     |
-| 00:00~00:00 | 발표 제목                     | 발표자, 소속                      | [pdf](https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-YYYY/파일명.pdf) |
-| 00:00~00:00 | 네트워킹                      | All                              | -     |
+## 이런 분께 추천
 
-## 발표자료
+- 기업에서 오픈소스 컴플라이언스 정책을 운영하거나 새로 도입하려는 담당자
+- OpenChain(ISO 5230), SBOM, 보안 취약점 대응 실무를 고민하는 조직
+- 다른 회사의 사례를 듣고 실무 네트워크를 넓히고 싶은 분
 
-| 제목 | 발표자 | 자료 |
-|---|---|---|
-| 발표 제목 | 발표자명 | [PDF](https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-YYYY/파일명.pdf) | -->
+## 아젠다
 
-<!--
-첨부파일 업로드 방법:
-1. GitHub Releases 페이지 접속:
-   https://github.com/OpenChain-Project/OpenChain-KWG/releases/tag/meeting-slides-YYYY
-   (YYYY를 해당 연도로 변경. 태그가 없으면 새로 생성)
-2. 파일명 규칙 준수:
-   - 영문, 숫자, 하이픈(-), 언더스코어(_), 점(.)만 사용
-   - 공백·한글·특수문자 사용 금지
-   - 권장 형식: YYYYMMDD-발표자-주제키워드.pdf
-3. 업로드 후 다운로드 URL 복사:
-   https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-YYYY/파일명.pdf
-4. 위 표의 링크 URL을 복사한 URL로 교체
--->
+> 세부 프로그램은 준비 중입니다. 확정되는 대로 이 페이지에 공개하고 메일링리스트로 안내드립니다. 발표하거나 함께 논의하고 싶은 주제가 있으면 메일링리스트로 제안해 주세요.
 
 ## Sponsor
 
-![](../../../images/content/about/logo/cj.png)
-
-
-<!--
-미팅 후 Flickr 앨범이 생성되면 아래 embed 코드를 교체하세요.
-<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/ALBUM_ID" title="ALBUM_TITLE"><img src="THUMBNAIL_URL" width="1024" height="768" alt="ALBUM_TITLE"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
--->
+<div class="kwg-conf-sponsor">
+  <span class="kwg-conf-sponsor__label">이번 미팅 후원</span>
+  <img src="../../../images/content/about/logo/cj.png" alt="CJ">
+</div>


### PR DESCRIPTION
## 개요

문서형이던 31차 미팅 페이지(2026-09-08, CJ)를 30차와 동일한 홍보형 랜딩 레이아웃으로 개선합니다. 아직 확정되지 않은 아젠다·발표자는 정직한 예고형으로 처리했습니다.

## 변경 내용

- `type: docs` → `type: meeting` + `layout: landing`
- 히어로(일시·장소·메일링리스트 가입 CTA·지도 링크), 키워드 칩, '이런 분께 추천'
- 아젠다는 '확정되는 대로 공개' 안내 + 발표 제안 안내로 구성
- 스폰서 색 토큰을 CJ 레드(#e30613)로, 스폰서 로고 CJ
- 지도: ko 네이버지도+카카오맵(CJ인재원 검색), en Google Maps
- ko/en 동기화

## 검증

- `hugo --minify` 빌드 성공, h1 중복 없음 확인
- `.claude/gate.sh` 통과
- ko-style 린트 0건