### PR TITLE
fix(conformance): Conformance Group 페이지에 ISO/IEC 18974 반영

### DIFF
--- a/content/en/subgroup/conformance/_index.md
+++ b/content/en/subgroup/conformance/_index.md
@@ -3,22 +3,22 @@ title: "Conformance Group"
 weight: 3
 type: docs
 description: >
-  We study how to achieve OpenChain Conformance.
+  We study how to achieve ISO/IEC 5230 and ISO/IEC 18974 Conformance.
 ---
 
 ## Prpose
 
-The OpenChain Project provides an [online self-authentication](https://certification.openchainproject.org/) that allows companies to self-verify whether they meet the OpenChain Specification.
+The OpenChain Project publishes ISO/IEC 5230, the standard for open source license compliance, and ISO/IEC 18974, the standard for open source security assurance. It provides an [online self-authentication](https://certification.openchainproject.org/) that allows companies to self-verify whether they meet either standard.
 
-With self-certification, companies can determine what is missing and what additional activities are required. If a company with a well-established open source compliance system can answer Yes to all inquries in the OpenChain's self-certification questionnaire, this can be submitted on the website (Conforming Submission). This will allow you to be recognized as an OpenChain Conformant company, as well as add your company's logo to the list of companies with OpenChain compliance programs on the website of the OpenChain project.
+With self-certification, companies can determine what is missing and what additional activities are required. If a company with a well-established open source compliance system can answer Yes to all inquries in the ISO/IEC 5230 or ISO/IEC 18974 self-certification questionnaire, this can be submitted on the website (Conforming Submission). This will allow you to be recognized as a Conformant company for that standard, as well as add your company's logo to the list of companies with conformant programs on the website of the OpenChain project.
 
-The Conformance Group is to study and share the best practices and activities that companies must undertake to build these OpenChain Conformant programs.
+The Conformance Group is to study and share the best practices and activities that companies must undertake to build these ISO/IEC 5230 and ISO/IEC 18974 Conformant programs.
 
-If you are an open source person in charge of a company looking to build an OpenChain Conformant program, please contact Conformance Group!
+If you are an open source person in charge of a company looking to build an ISO/IEC 5230 or ISO/IEC 18974 Conformant program, please contact Conformance Group!
 
 ## Subscribe
 
-Conformance Group is open to any OpenChain KWG member interested in building an OpenChain Conformant program. Please apply for membership by e-mail to the group Lead (Haksung Jang, haksung@sk.com).
+Conformance Group is open to any OpenChain KWG member interested in building an ISO/IEC 5230 or ISO/IEC 18974 Conformant program. Please apply for membership by e-mail to the group Lead (Haksung Jang, haksung@sk.com).
 
 ## mailing list
 

--- a/content/ko/subgroup/conformance/_index.md
+++ b/content/ko/subgroup/conformance/_index.md
@@ -3,22 +3,22 @@ title: "Conformance Group"
 weight: 3
 type: docs
 description: >
-  ISO/IEC 5230을 준수하기 위한 방법을 연구합니다. 
+  ISO/IEC 5230과 ISO/IEC 18974를 준수하기 위한 방법을 연구합니다. 
 ---
 
 ## 목적
 
-OpenChain Project는 기업이 ISO/IEC 5230을 충족하는지 자체적으로 확인할 수 있도록 [온라인 자체 인증 방법](https://certification.openchainproject.org/)을 제공합니다.
+OpenChain Project는 오픈소스 라이선스 컴플라이언스 표준인 ISO/IEC 5230과 오픈소스 보안 보증 표준인 ISO/IEC 18974를 발행하고 있습니다. 기업이 두 표준을 충족하는지 자체적으로 확인할 수 있도록 [온라인 자체 인증 방법](https://certification.openchainproject.org/)을 제공합니다.
 
-기업은 자체 인증을 통해 부족한 부분이 무엇인지, 추가로 필요한 활동이 무엇인지 판단할 수 있습니다. 만약, 오픈소스 컴플라이언스 체계가 잘 구축된 기업이 ISO/IEC 5230 자체 인증 질문지의 모든 항목을 Yes로 대답할 수 있다면 이 결과를 웹사이트상에 제출할 수 있습니다(Conforming Submission). 그러면 ISO/IEC 5230 준수(Conformant) 기업으로 인정됨과 동시에, OpenChain 프로젝트의 웹사이트에서 ISO/IEC 5230 준수 프로그램을 갖춘 기업 목록에 기업의 로고를 등록할 수 있게 됩니다.
+기업은 자체 인증을 통해 부족한 부분이 무엇인지, 추가로 필요한 활동이 무엇인지 판단할 수 있습니다. 만약, 오픈소스 컴플라이언스 체계가 잘 구축된 기업이 ISO/IEC 5230 또는 ISO/IEC 18974 자체 인증 질문지의 모든 항목을 Yes로 대답할 수 있다면 이 결과를 웹사이트상에 제출할 수 있습니다(Conforming Submission). 그러면 해당 표준 준수(Conformant) 기업으로 인정됨과 동시에, OpenChain 프로젝트의 웹사이트에서 준수 프로그램을 갖춘 기업 목록에 기업의 로고를 등록할 수 있게 됩니다.
 
-Conformance Group은 기업이 이러한 ISO/IEC 5230 Conformant 프로그램을 구축하기 위해 수행해야 하는 활동 및 Best Practice를 연구하고 공유하기 위한 그룹입니다. 
+Conformance Group은 기업이 이러한 ISO/IEC 5230 및 ISO/IEC 18974 Conformant 프로그램을 구축하기 위해 수행해야 하는 활동 및 Best Practice를 연구하고 공유하기 위한 그룹입니다. 
 
-ISO/IEC 5230 Conformant 프로그램을 구축하고자 하는 기업의 담당자는 Conformance Group으로 연락주세요!
+ISO/IEC 5230 또는 ISO/IEC 18974 Conformant 프로그램을 구축하고자 하는 기업의 담당자는 Conformance Group으로 연락주세요!
 
 ## 가입 문의
 
-Conformance Group은 ISO/IEC 5230 Conformant 프로그램 구축에 관심이 있는 누구든지 가입할 수 있습니다. 그룹 Lead(장학성, haksung@sk.com)에게 메일로 가입 신청해 주세요. 
+Conformance Group은 ISO/IEC 5230 또는 ISO/IEC 18974 Conformant 프로그램 구축에 관심이 있는 누구든지 가입할 수 있습니다. 그룹 Lead(장학성, haksung@sk.com)에게 메일로 가입 신청해 주세요. 
 
 ## 메일링리스트
 


### PR DESCRIPTION
## 배경

`subgroup/conformance/` 페이지가 ISO/IEC 5230만 언급하고 있었으나, Conformance Group이 다루는 OpenChain 표준에는 보안 보증 표준인 ISO/IEC 18974도 포함됩니다.

## 변경

- description, 목적, Conforming Submission·Conformant·가입 문의 문장에 ISO/IEC 18974 병기
- ISO/IEC 5230(라이선스 컴플라이언스)과 ISO/IEC 18974(보안 보증)의 성격 구분 명시
- ko/en 동기화
- 로컬 `npm run build` 통과