### PR TITLE
fix(conformance): 폐기된 certification.openchainproject.org 링크 교체

### DIFF
--- a/content/en/subgroup/conformance/_index.md
+++ b/content/en/subgroup/conformance/_index.md
@@ -8,7 +8,7 @@ description: >
 
 ## Prpose
 
-The OpenChain Project publishes ISO/IEC 5230, the standard for open source license compliance, and ISO/IEC 18974, the standard for open source security assurance. It provides an [online self-authentication](https://certification.openchainproject.org/) that allows companies to self-verify whether they meet either standard.
+The OpenChain Project publishes ISO/IEC 5230, the standard for open source license compliance, and ISO/IEC 18974, the standard for open source security assurance. It provides [self-certification checklists and a conformance process](https://www.openchainproject.org/get-started/conformance) that allow companies to self-verify whether they meet either standard.
 
 With self-certification, companies can determine what is missing and what additional activities are required. If a company with a well-established open source compliance system can answer Yes to all inquries in the ISO/IEC 5230 or ISO/IEC 18974 self-certification questionnaire, this can be submitted on the website (Conforming Submission). This will allow you to be recognized as a Conformant company for that standard, as well as add your company's logo to the list of companies with conformant programs on the website of the OpenChain project.
 

--- a/content/ko/subgroup/conformance/_index.md
+++ b/content/ko/subgroup/conformance/_index.md
@@ -8,7 +8,7 @@ description: >
 
 ## 목적
 
-OpenChain Project는 오픈소스 라이선스 컴플라이언스 표준인 ISO/IEC 5230과 오픈소스 보안 보증 표준인 ISO/IEC 18974를 발행하고 있습니다. 기업이 두 표준을 충족하는지 자체적으로 확인할 수 있도록 [온라인 자체 인증 방법](https://certification.openchainproject.org/)을 제공합니다.
+OpenChain Project는 오픈소스 라이선스 컴플라이언스 표준인 ISO/IEC 5230과 오픈소스 보안 보증 표준인 ISO/IEC 18974를 발행하고 있습니다. 기업이 두 표준을 충족하는지 자체적으로 확인할 수 있도록 [자체 인증 체크리스트와 컨포먼스 절차](https://www.openchainproject.org/get-started/conformance)를 제공합니다.
 
 기업은 자체 인증을 통해 부족한 부분이 무엇인지, 추가로 필요한 활동이 무엇인지 판단할 수 있습니다. 만약, 오픈소스 컴플라이언스 체계가 잘 구축된 기업이 ISO/IEC 5230 또는 ISO/IEC 18974 자체 인증 질문지의 모든 항목을 Yes로 대답할 수 있다면 이 결과를 웹사이트상에 제출할 수 있습니다(Conforming Submission). 그러면 해당 표준 준수(Conformant) 기업으로 인정됨과 동시에, OpenChain 프로젝트의 웹사이트에서 준수 프로그램을 갖춘 기업 목록에 기업의 로고를 등록할 수 있게 됩니다.
 


### PR DESCRIPTION
## 배경

Conformance Group 페이지가 가리키던 `https://certification.openchainproject.org/` 가 더 이상 동작하지 않습니다(도메인 DNS 폐기, `ENOTFOUND`).

OpenChain은 단독 자체 인증 웹앱을 폐기하고 공식 사이트의 `get-started/conformance` 페이지로 통합했습니다. 이 페이지가 ISO/IEC 5230·ISO/IEC 18974 자체 인증 체크리스트와 컨포먼스 신청 절차를 모두 안내합니다.

## 변경

- 죽은 링크를 `https://www.openchainproject.org/get-started/conformance` 로 교체
- 링크 문구를 실제 제공 형태(체크리스트·컨포먼스 절차)에 맞게 조정
- ko/en 동기화
- 로컬 `npm run build` 통과