### PR TITLE
31차 페이지 발표 주제 모집 안내 되돌리기

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -991,38 +991,6 @@ a.kwg-hero__badge:hover {
 }
 .kwg-conf-sponsor img { max-width: 170px; width: 100%; height: auto; }
 
-// 모집 안내(발표 주제 공모 등) — 아젠다가 미확정인 회차에서 그 자리를 채운다.
-// 카드는 뉴트럴하게 두고 accent 는 CTA 버튼에만(스폰서 카드와 같은 위계).
-.kwg-conf-callout {
-  padding: clamp($space-5, 4vw, $space-7);
-  border-radius: 1rem;
-  background: var(--bs-body-bg);
-  border: 1px solid var(--bs-border-color);
-  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
-}
-.kwg-conf-callout__title {
-  font-size: $text-lg;
-  font-weight: 600;
-  color: var(--bs-emphasis-color);
-  margin: 0 0 $space-3;
-}
-.kwg-conf-callout__desc {
-  color: var(--bs-secondary-color);
-  line-height: 1.6;
-  margin: 0 0 $space-4;
-}
-.kwg-conf-callout__list {
-  margin: 0 0 $space-5;
-  padding-left: 1.1rem;
-  color: var(--bs-body-color);
-  li { margin-bottom: $space-2; }
-}
-.kwg-conf-callout__deadline {
-  margin: $space-4 0 0;
-  font-size: $text-sm;
-  color: var(--bs-secondary-color);
-}
-
 @media (max-width: 480px) {
   .kwg-conf-tl { grid-template-columns: 76px 24px 1fr; gap: 0 $space-3; }
   .kwg-conf-tl__time { font-size: $text-sm; }
@@ -1043,7 +1011,6 @@ a.kwg-hero__badge:hover {
     .kwg-subcard,
     .kwg-conf-speaker,
     .kwg-conf-tl,
-    .kwg-conf-callout,
     .kwg-conf-sponsor {
       animation: kwg-reveal-up both linear;
       animation-timeline: view();
@@ -1115,13 +1082,11 @@ a.kwg-hero__badge:hover {
   .kwg-conf-hero,
   .kwg-conf-hero__date,
   .kwg-conf-speaker,
-  .kwg-conf-callout,
   .kwg-conf-sponsor {
     box-shadow: none;
   }
   .kwg-conf-hero__date,
   .kwg-conf-speaker,
-  .kwg-conf-callout,
   .kwg-conf-sponsor {
     background: var(--bs-tertiary-bg);
   }

--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -21,7 +21,7 @@ aliases:
   <div class="kwg-conf-hero__body">
     <p class="kwg-conf-hero__eyebrow">31st Meeting</p>
     <h1 class="kwg-conf-hero__title">OpenChain KWG 31st Meeting</h1>
-    <p class="kwg-conf-hero__sub">We are preparing the autumn 2026 meeting together with CJ. We are currently collecting topics to share at the meeting.</p>
+    <p class="kwg-conf-hero__sub">We are preparing the autumn 2026 meeting together with CJ. The detailed program will be announced on this page and via the mailing list once confirmed.</p>
     <div class="kwg-conf-hero__meta">
       <span><strong>Date</strong> 2026-09-08 (Tue) 14:00–17:00</span>
       <span><strong>Venue</strong> CJ Human Resources Development Center · Jung-gu, Seoul</span>
@@ -52,22 +52,7 @@ aliases:
 
 ## Agenda
 
-The detailed program is in preparation. It will be published on this page and announced via the mailing list once confirmed.
-
-<div class="kwg-conf-callout">
-  <p class="kwg-conf-callout__title">Call for topics</p>
-  <p class="kwg-conf-callout__desc">We are looking for topics to share at the 31st meeting. It does not have to be a finished case study. Work still in progress often makes for the liveliest discussion, and if company details are sensitive, you are welcome to present anonymously or in generalized form.</p>
-  <ul class="kwg-conf-callout__list">
-    <li><strong>Session talk</strong> about 25 minutes, with separate time for Q&amp;A</li>
-    <li><strong>Topics you want to hear</strong> subjects you hope someone else will share, even if you cannot present</li>
-    <li><strong>Lightning talk</strong> a brief 5 to 10 minute introduction to a topic</li>
-    <li><strong>Group discussion topic</strong> something to take up during the discussion session</li>
-  </ul>
-  <div class="kwg-conf-hero__cta">
-    <a class="kwg-conf-cta" href="https://github.com/OpenChain-KWG/meeting/discussions/15" target="_blank" rel="noopener">Propose a topic</a>
-  </div>
-  <p class="kwg-conf-callout__deadline">Proposals submitted by August 14, 2026 (Fri) will be considered for the program. The discussion thread is written in Korean.</p>
-</div>
+> The detailed program is in preparation. It will be published on this page and announced via the mailing list once confirmed. If you have a topic you would like to present or discuss, please propose it through the mailing list.
 
 ## Sponsor
 

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -21,7 +21,7 @@ aliases:
   <div class="kwg-conf-hero__body">
     <p class="kwg-conf-hero__eyebrow">31st Meeting</p>
     <h1 class="kwg-conf-hero__title">OpenChain KWG 31차 정기 모임</h1>
-    <p class="kwg-conf-hero__sub">2026년 가을 정기 모임을 CJ와 함께 준비하고 있습니다. 지금은 함께 나눌 발표 주제를 모집하고 있습니다.</p>
+    <p class="kwg-conf-hero__sub">2026년 가을 정기 모임을 CJ와 함께 준비하고 있습니다. 세부 프로그램은 확정되는 대로 이 페이지와 메일링리스트로 안내드립니다.</p>
     <div class="kwg-conf-hero__meta">
       <span><strong>일시</strong> 2026-09-08 (화) 14:00–17:00</span>
       <span><strong>장소</strong> CJ인재원 · 서울 중구</span>
@@ -53,22 +53,7 @@ aliases:
 
 ## 아젠다
 
-세부 프로그램은 준비 중입니다. 확정되는 대로 이 페이지에 공개하고 메일링리스트로 안내드립니다.
-
-<div class="kwg-conf-callout">
-  <p class="kwg-conf-callout__title">발표 주제를 모집합니다</p>
-  <p class="kwg-conf-callout__desc">31차 모임에서 함께 나눌 주제를 기다립니다. 완성된 사례가 아니어도 좋습니다. 진행 중인 고민이 오히려 토의를 활발하게 만듭니다. 사내 사정으로 회사명을 밝히기 어려우면 익명이나 일반화된 형태로 발표하셔도 됩니다.</p>
-  <ul class="kwg-conf-callout__list">
-    <li><strong>주제 발표</strong> 25분 내외, 질의응답 시간 별도</li>
-    <li><strong>듣고 싶은 주제</strong> 직접 발표하지 않더라도 누군가 공유해 주기를 바라는 주제</li>
-    <li><strong>라이트닝 토크</strong> 5분에서 10분 정도로 가볍게 소개하는 시간</li>
-    <li><strong>그룹 토의 주제</strong> 모임 후반 토의 시간에 다루고 싶은 주제</li>
-  </ul>
-  <div class="kwg-conf-hero__cta">
-    <a class="kwg-conf-cta" href="https://github.com/OpenChain-KWG/meeting/discussions/15" target="_blank" rel="noopener">발표 주제 제안하기</a>
-  </div>
-  <p class="kwg-conf-callout__deadline">제안은 2026년 8월 14일(금)까지 남겨 주시면 프로그램 편성에 반영합니다.</p>
-</div>
+> 세부 프로그램은 준비 중입니다. 확정되는 대로 이 페이지에 공개하고 메일링리스트로 안내드립니다. 발표하거나 함께 논의하고 싶은 주제가 있으면 메일링리스트로 제안해 주세요.
 
 ## Sponsor
 


### PR DESCRIPTION
PR #325에서 추가한 31차 페이지의 발표 주제 모집 안내를 내립니다.

되돌린 범위는 PR #325 전체입니다. 모집 카드(ko/en), 함께 추가했던 `.kwg-conf-callout` 계열 클래스, 히어로 소개 문장 수정까지 포함해 원래 상태로 복원했습니다.

`npm run build` 성공을 확인했습니다.