### PR TITLE
31차 지도 링크 추가와 그룹 토의 설명 삭제

### DIFF
--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -29,7 +29,9 @@ aliases:
     <p class="kwg-conf-hero__note">Registration and the detailed program are announced via the OpenChain KWG mailing list. Subscribe to receive the sign-up link.</p>
     <div class="kwg-conf-hero__cta">
       <a class="kwg-conf-cta" href="../../../about/subscribe/">Join the mailing list</a>
-      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://maps.app.goo.gl/nQUogVHPvF4VuapX9" target="_blank" rel="noopener">Open in Google Maps</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://maps.app.goo.gl/nQUogVHPvF4VuapX9" target="_blank" rel="noopener">Google Maps</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.naver.com/p/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">Naver Map</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.kakao.com/link/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">Kakao Map</a>
     </div>
   </div>
   <div class="kwg-conf-hero__date">
@@ -95,7 +97,6 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">Group Discussion</div>
       <div class="kwg-conf-tl__by">All Participants</div>
-      <p class="kwg-conf-tl__desc">Starting with this meeting, the group discussion moves to the middle of the program so that questions raised by the talks can be shared right away.</p>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -31,6 +31,7 @@ aliases:
       <a class="kwg-conf-cta" href="../../../about/subscribe/">메일링리스트 가입</a>
       <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.naver.com/p/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">네이버지도</a>
       <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.kakao.com/link/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">카카오맵</a>
+      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://maps.app.goo.gl/nQUogVHPvF4VuapX9" target="_blank" rel="noopener">구글맵</a>
     </div>
   </div>
   <div class="kwg-conf-hero__date">
@@ -96,7 +97,6 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">그룹 토의</div>
       <div class="kwg-conf-tl__by">All Participants</div>
-      <p class="kwg-conf-tl__desc">이번 회차부터 그룹 토의를 중간 시간대에 배치합니다. 발표를 듣고 생긴 질문을 바로 나눌 수 있도록 하기 위해서입니다.</p>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">


### PR DESCRIPTION
지도 링크를 ko/en 양쪽에서 통일합니다. 국문 페이지에 구글맵을, 영문 페이지에 네이버지도와 카카오맵을 추가했습니다. 외국인 참석자는 구글맵으로 위치를 찾고, 현지 이동에는 네이버지도나 카카오맵을 쓸 수 있습니다.

그룹 토의 항목의 배치 이유 설명은 지웠습니다. 프로그램 안내에 필요한 정보가 아닙니다.