### PR TITLE
지도 링크를 CTA 버튼에서 장소 안내 줄로 이동

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -765,6 +765,13 @@ a.kwg-hero__badge:hover {
   margin: 0 0 $space-6;
 }
 .kwg-conf-hero__meta strong { font-weight: 600; color: var(--bs-emphasis-color); margin-right: $space-2; }
+// 지도 링크 — CTA가 아니라 장소 정보에 딸린 보조 링크
+.kwg-conf-hero__maps {
+  margin: -$space-4 0 $space-6;
+  font-size: $text-sm;
+  color: var(--bs-secondary-color);
+}
+.kwg-conf-hero__maps a { margin-right: $space-3; }
 
 // CTA — accent 배경 + 어두운 ink 글자(노랑 위 흰 글자 금지)
 .kwg-conf-cta {

--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -26,12 +26,14 @@ aliases:
       <span><strong>Date</strong> 2026-09-08 (Tue) 14:00–17:00</span>
       <span><strong>Venue</strong> CJ Human Resources Development Center · Jung-gu, Seoul</span>
     </div>
+    <p class="kwg-conf-hero__maps">Directions
+      <a href="https://maps.app.goo.gl/nQUogVHPvF4VuapX9" target="_blank" rel="noopener">Google Maps</a>
+      <a href="https://map.naver.com/p/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">Naver Map</a>
+      <a href="https://map.kakao.com/link/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">Kakao Map</a>
+    </p>
     <p class="kwg-conf-hero__note">Registration and the detailed program are announced via the OpenChain KWG mailing list. Subscribe to receive the sign-up link.</p>
     <div class="kwg-conf-hero__cta">
       <a class="kwg-conf-cta" href="../../../about/subscribe/">Join the mailing list</a>
-      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://maps.app.goo.gl/nQUogVHPvF4VuapX9" target="_blank" rel="noopener">Google Maps</a>
-      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.naver.com/p/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">Naver Map</a>
-      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.kakao.com/link/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">Kakao Map</a>
     </div>
   </div>
   <div class="kwg-conf-hero__date">

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -26,12 +26,14 @@ aliases:
       <span><strong>일시</strong> 2026-09-08 (화) 14:00–17:00</span>
       <span><strong>장소</strong> CJ인재원 · 서울 중구</span>
     </div>
+    <p class="kwg-conf-hero__maps">길찾기
+      <a href="https://map.naver.com/p/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">네이버지도</a>
+      <a href="https://map.kakao.com/link/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">카카오맵</a>
+      <a href="https://maps.app.goo.gl/nQUogVHPvF4VuapX9" target="_blank" rel="noopener">구글맵</a>
+    </p>
     <p class="kwg-conf-hero__note">참가 신청과 세부 프로그램은 OpenChain KWG 메일링리스트로 안내됩니다. 가입하시면 신청 링크를 받아보실 수 있습니다.</p>
     <div class="kwg-conf-hero__cta">
       <a class="kwg-conf-cta" href="../../../about/subscribe/">메일링리스트 가입</a>
-      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.naver.com/p/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">네이버지도</a>
-      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://map.kakao.com/link/search/CJ%EC%9D%B8%EC%9E%AC%EC%9B%90" target="_blank" rel="noopener">카카오맵</a>
-      <a class="kwg-conf-cta kwg-conf-cta--ghost" href="https://maps.app.goo.gl/nQUogVHPvF4VuapX9" target="_blank" rel="noopener">구글맵</a>
     </div>
   </div>
   <div class="kwg-conf-hero__date">


### PR DESCRIPTION
히어로의 버튼이 네 개(메일링리스트 가입, 지도 3종)라 실제로 눌러야 할 메일링리스트 가입이 묻혔습니다. 지도는 버튼에서 빼고 장소 정보 아래 작은 링크 줄로 옮깁니다.

- 버튼은 메일링리스트 가입 하나만 남깁니다
- 지도 3종은 `.kwg-conf-hero__maps` 줄에 텍스트 링크로 배치합니다
- ko는 네이버지도·카카오맵·구글맵, en은 Google Maps·Naver Map·Kakao Map 순서입니다

다음 회차 페이지도 같은 구조를 쓰면 됩니다.