### PR TITLE
about 사이드 메뉴의 Charter 항목을 영문 표기로 통일

### DIFF
--- a/content/ko/about/Charter/_index.md
+++ b/content/ko/about/Charter/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "OpenChain Korea Work Group 정관"
-linkTitle: "정관"
+linkTitle: "Charter"
 weight: 2
 type: docs
 categories: ["about"]


### PR DESCRIPTION
국문 사이트의 about 사이드 메뉴에서 Charter만 '정관'으로 표시돼 나머지 항목(Welcome Package, Subscribe, Member, Contact, Code of Conduct)과 어긋났습니다.

linkTitle을 Charter로 바꿉니다. 본문 제목(title)은 'OpenChain Korea Work Group 정관' 그대로 두어, Subscribe 페이지와 같은 방식(본문 제목은 한국어, 메뉴는 영문)을 따릅니다.