### PR TITLE
meeting: 31차 페이지에 CJ 확정 아젠다 반영

### DIFF
--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -5,7 +5,7 @@ weight: 31
 type: meeting
 layout: landing
 categories: ["meeting"]
-tags: ["OpenChain", "CRA", "SBOM", "SupplyChainSecurity", "Automation", "CJ"]
+tags: ["OpenChain", "CRA", "SBOM", "SupplyChainSecurity", "Governance", "CJ"]
 description: >
   September 8, 2026 (Tue) / CJ
 aliases:
@@ -20,8 +20,8 @@ aliases:
 <div class="kwg-conf-hero">
   <div class="kwg-conf-hero__body">
     <p class="kwg-conf-hero__eyebrow">31st Meeting</p>
-    <h1 class="kwg-conf-hero__title">Software Supply Chain Security and Open Source Management Automation</h1>
-    <p class="kwg-conf-hero__sub">We look at CJ Group's open source management practices and its response to the EU Cyber Resilience Act (CRA), automation from an operations team's perspective, and tools for software supply chain security.</p>
+    <h1 class="kwg-conf-hero__title">Software Supply Chain Security and Open Source Governance</h1>
+    <p class="kwg-conf-hero__sub">We look at the state of open source governance at CJ Group, how an open source management framework runs from an operations team's perspective, and tools for software supply chain security.</p>
     <div class="kwg-conf-hero__meta">
       <span><strong>Date</strong> 2026-09-08 (Tue) 14:00–17:00</span>
       <span><strong>Venue</strong> CJ Human Resources Development Center · Jung-gu, Seoul</span>
@@ -45,7 +45,7 @@ aliases:
 <ul class="kwg-conf-chips">
   <li class="kwg-conf-chip">OpenChain</li>
   <li class="kwg-conf-chip">EU CRA</li>
-  <li class="kwg-conf-chip">Automation</li>
+  <li class="kwg-conf-chip">OSS Governance</li>
   <li class="kwg-conf-chip">Supply Chain Security</li>
   <li class="kwg-conf-chip">SBOM</li>
 </ul>
@@ -53,7 +53,7 @@ aliases:
 ## Who Should Attend
 
 - Practitioners preparing for ISO 5230 or ISO 18974 self-certification, or working out the scope of their EU Cyber Resilience Act (CRA) response
-- Organizations looking to automate open source management and cut operational load with tooling
+- Organizations looking to streamline open source management and cut operational load with tooling
 - Teams starting on software supply chain security or needing to verify SBOMs received from suppliers
 - Anyone who wants to hear other companies' cases and expand their practitioner network
 
@@ -80,9 +80,9 @@ aliases:
     <div class="kwg-conf-tl__time">14:30–14:55</div>
     <div class="kwg-conf-tl__marker"></div>
     <div class="kwg-conf-tl__body">
-      <div class="kwg-conf-tl__title">Session 1. Open Source Management Best Practices at CJ Group (working title)</div>
+      <div class="kwg-conf-tl__title">Session 1. The State of Open Source Governance at CJ Group</div>
       <div class="kwg-conf-tl__by">Kiyoung Sung, Patent Attorney · CJ</div>
-      <p class="kwg-conf-tl__desc">CJ Group's open source management framework, including its experience joining the OSSORI project and its activities in response to the EU Cyber Resilience Act (CRA).</p>
+      <p class="kwg-conf-tl__desc">CJ Group's open source governance framework, told through three core topics: certification status across the group, data contributions to the OSSORI project, and the response to the EU Cyber Resilience Act (CRA).</p>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--muted">
@@ -105,9 +105,9 @@ aliases:
     <div class="kwg-conf-tl__time">15:55–16:20</div>
     <div class="kwg-conf-tl__marker"></div>
     <div class="kwg-conf-tl__body">
-      <div class="kwg-conf-tl__title">Session 2. Automating Open Source Management (working title)</div>
+      <div class="kwg-conf-tl__title">Session 2. OSS Governance That Centers People and Grows with the System</div>
       <div class="kwg-conf-tl__by">Olive Networks</div>
-      <p class="kwg-conf-tl__desc">How an operations team automated its open source management work, and the results of applying it.</p>
+      <p class="kwg-conf-tl__desc">Experience running OSS Governance across CJ Group's many organizations and affiliates, and how it grew into a framework that carries on even when the people change.</p>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -5,7 +5,7 @@ weight: 31
 type: meeting
 layout: landing
 categories: ["meeting"]
-tags: ["OpenChain", "CRA", "SBOM", "공급망보안", "자동화", "CJ"]
+tags: ["OpenChain", "CRA", "SBOM", "공급망보안", "거버넌스", "CJ"]
 description: >
   2026년 9월 8일 (화) / CJ
 aliases:
@@ -20,8 +20,8 @@ aliases:
 <div class="kwg-conf-hero">
   <div class="kwg-conf-hero__body">
     <p class="kwg-conf-hero__eyebrow">31st Meeting</p>
-    <h1 class="kwg-conf-hero__title">소프트웨어 공급망 보안과 오픈소스 관리 자동화</h1>
-    <p class="kwg-conf-hero__sub">CJ 그룹의 오픈소스 관리 사례와 EU 사이버 복원력법(CRA) 대응 활동, 운영팀 관점의 관리 자동화, 소프트웨어 공급망 보안을 위한 도구를 함께 살펴봅니다.</p>
+    <h1 class="kwg-conf-hero__title">소프트웨어 공급망 보안과 오픈소스 관리 운영체계</h1>
+    <p class="kwg-conf-hero__sub">CJ 그룹의 오픈소스 거버넌스 현황과 운영팀 관점의 오픈소스 관리 운영체계, 소프트웨어 공급망 보안을 위한 도구를 함께 살펴봅니다.</p>
     <div class="kwg-conf-hero__meta">
       <span><strong>일시</strong> 2026-09-08 (화) 14:00–17:00</span>
       <span><strong>장소</strong> CJ인재원 · 서울 중구</span>
@@ -45,7 +45,7 @@ aliases:
 <ul class="kwg-conf-chips">
   <li class="kwg-conf-chip">OpenChain</li>
   <li class="kwg-conf-chip">EU CRA</li>
-  <li class="kwg-conf-chip">관리 자동화</li>
+  <li class="kwg-conf-chip">OSS 거버넌스</li>
   <li class="kwg-conf-chip">공급망 보안</li>
   <li class="kwg-conf-chip">SBOM</li>
 </ul>
@@ -53,7 +53,7 @@ aliases:
 ## 이런 분께 추천
 
 - ISO 5230·ISO 18974 자체 인증을 준비하거나 EU 사이버 복원력법(CRA) 대응 범위를 정리하고 있는 담당자
-- 오픈소스 관리 업무를 자동화하고 도구로 운영 부담을 줄이려는 조직
+- 오픈소스 관리 업무를 효율화하고 도구로 운영 부담을 줄이려는 조직
 - 소프트웨어 공급망 보안 대응을 시작했거나 공급사에서 받는 SBOM을 검증해야 하는 팀
 - 다른 회사의 사례를 듣고 실무 네트워크를 넓히고 싶은 분
 
@@ -80,9 +80,9 @@ aliases:
     <div class="kwg-conf-tl__time">14:30–14:55</div>
     <div class="kwg-conf-tl__marker"></div>
     <div class="kwg-conf-tl__body">
-      <div class="kwg-conf-tl__title">Session 1. CJ 그룹 오픈소스 관리 우수 사례 (가제)</div>
+      <div class="kwg-conf-tl__title">Session 1. CJ 그룹 오픈소스 거버넌스 현황</div>
       <div class="kwg-conf-tl__by">성기영 변리사 · CJ</div>
-      <p class="kwg-conf-tl__desc">오소리(OSSORI) 프로젝트 가입 경험과 EU 사이버 복원력법(CRA) 대응 활동을 포함해 CJ 그룹의 오픈소스 관리 체계를 공유합니다.</p>
+      <p class="kwg-conf-tl__desc">그룹 내 오픈소스 인증 현황, 오소리(OSSORI) 데이터 기여 현황, EU 사이버 복원력법(CRA) 대응 현황 등 세 가지 핵심 주제를 바탕으로 CJ 그룹의 오픈소스 거버넌스 체계를 공유합니다.</p>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--muted">
@@ -105,9 +105,9 @@ aliases:
     <div class="kwg-conf-tl__time">15:55–16:20</div>
     <div class="kwg-conf-tl__marker"></div>
     <div class="kwg-conf-tl__body">
-      <div class="kwg-conf-tl__title">Session 2. 오픈소스 관리 자동화 방안 (가제)</div>
+      <div class="kwg-conf-tl__title">Session 2. 사람을 중심으로, 시스템과 함께 성장하는 OSS Governance</div>
       <div class="kwg-conf-tl__by">올리브네트웍스</div>
-      <p class="kwg-conf-tl__desc">운영팀 관점에서 오픈소스 관리 업무를 자동화한 방식과 적용 결과를 공유합니다.</p>
+      <p class="kwg-conf-tl__desc">CJ 그룹의 다양한 조직과 계열사를 연결하는 OSS Governance 운영 경험과, 사람이 바뀌어도 이어지는 운영체계로 발전시킨 과정을 공유합니다.</p>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">


### PR DESCRIPTION
CJ가 보내온 안내문 기준으로 31차 미팅 페이지(ko/en)를 보완했다.

- 대주제를 "오픈소스 관리 자동화"에서 "오픈소스 관리 운영체계"로 변경
- 부제를 CJ 문안(거버넌스 현황 + 운영체계 + 공급망 보안 도구)으로 교체
- Session 1: 제목을 "CJ 그룹 오픈소스 거버넌스 현황"으로 확정하고, 인증 현황·오소리(OSSORI) 데이터 기여 현황·EU 사이버 복원력법(CRA) 대응 현황 세 주제로 소개 교체
- Session 2: 제목을 "사람을 중심으로, 시스템과 함께 성장하는 OSS Governance"로 확정하고 소개 교체
- 추천 대상 문구와 주제어 칩·태그를 거버넌스 기준으로 정리

Session 3, 시간표, 저녁 식사, 스폰서는 CJ 문서와 일치해 그대로 두었다.
빌드와 .claude/gate.sh 통과 확인.