### PR TITLE
fix: alert 박스 왼쪽 악센트 바 제거

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -176,9 +176,20 @@ h1.td-title { font-size: 1.75rem; font-weight: 500; letter-spacing: -0.022em; }
 }
 
 // alert/pageinfo 박스 — 홈 카드 톤(둥근 모서리)
+// Docsy 기본값(왼쪽만 4px 악센트 바)은 AI 생성 문서의 콜아웃처럼 보여
+// 전체 테두리 얇은 카드 톤으로 바꾼다.
 .td-content .alert,
 .pageinfo {
   border-radius: $border-radius;
+  box-shadow: $box-shadow-sm;
+}
+.td-content .alert {
+  @each $color, $value in $theme-colors {
+    &-#{$color} {
+      border-width: 1px;
+      border-color: rgba($value, 0.25);
+    }
+  }
 }
 
 // 본문 줄 길이 80% 제한 해제 — pageinfo와 폭 통일


### PR DESCRIPTION
## Summary
- Docsy 기본 alert 스타일의 왼쪽 4px 악센트 바를 4방향 1px 테두리 + 카드 그림자로 변경
- info/success/warning 등 모든 색상 변형에 공통 적용

## Test plan
- [x] npm run build 통과
- [x] 로컬 서버에서 info/success/warning 색상 alert 박스 렌더링 확인