### PR TITLE
fix: 31차 미팅 발표자료 링크 및 Tooling & Legal 30차 제목 수정

### DIFF
--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -74,6 +74,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">OpenChain Updates</div>
       <div class="kwg-conf-tl__by">KWG Steering Committee · OpenChain Project (global update)</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/31th-kwg-update-2026q3.pdf" target="_blank" rel="noopener">KWG Update (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">

--- a/content/en/subgroup/tooling-legal/30th-Meeting/_index.md
+++ b/content/en/subgroup/tooling-legal/30th-Meeting/_index.md
@@ -22,7 +22,7 @@ description: Tooling & Legal Subgroup 30th Meeting
 | No | Subject           | Speaker | Slide |
 |----|-----------------|------|------|
 | 0  | Community Updates & New Issues | TBD | TBD |
-| 1  | Introduction and Demo of Open Source Management Tools (BomLens/TRUSCA) | SK Telecom, Jang Haksung | TBD |
+| 1  | In-Depth Look at Open Source Management Tools (BomLens/TRUSCA) | SK Telecom, Jang Haksung | TBD |
 
 <!--
 

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -74,6 +74,7 @@ aliases:
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">OpenChain Updates</div>
       <div class="kwg-conf-tl__by">운영진 · OpenChain Project (글로벌 업데이트)</div>
+      <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/31th-kwg-update-2026q3.pdf" target="_blank" rel="noopener">KWG 업데이트 (PDF)</a>
     </div>
   </div>
   <div class="kwg-conf-tl kwg-conf-tl--session">

--- a/content/ko/subgroup/tooling-legal/30th-Meeting/_index.md
+++ b/content/ko/subgroup/tooling-legal/30th-Meeting/_index.md
@@ -24,4 +24,4 @@ description: Tooling & Legal Subgroup 30th Meeting
 | No | Subject           | Speaker | Slide |
 |----|-----------------|------|------|
 | 0  | Community Updates & New Issues | TBD | TBD |
-| 1  | 오픈소스 관리 도구 소개 및 데모 (BomLens/TRUSCA) | SK Telecom, 장학성 | TBD |
+| 1  | 오픈소스 관리 도구 심화 (BomLens/TRUSCA) | SK Telecom, 장학성 | TBD |


### PR DESCRIPTION
## Summary
- 31차 미팅 페이지(ko/en)에 KWG Update 발표자료(GitHub Releases PDF) 링크 추가
- Tooling & Legal 30차 발표 제목을 "소개 및 데모"에서 "심화"로 수정 (ko/en)

## Test plan
- [x] npm run build 성공
- [x] .claude/gate.sh 통과 (신규 blocking 없음)