### PR TITLE
fix: 31차 미팅 페이지 발표자 소개 위치·표기 정리

### DIFF
--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -73,7 +73,7 @@ aliases:
     <div class="kwg-conf-tl__marker"></div>
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">OpenChain Updates</div>
-      <div class="kwg-conf-tl__by">Mary Wang, Executive Director · Linux Foundation / KWG Steering Committee · OpenChain Project (global update)</div>
+      <div class="kwg-conf-tl__by">Mary Wang, Executive Director · Linux Foundation / KWG Steering Committee</div>
       <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/31th-kwg-update-2026q3.pdf" target="_blank" rel="noopener">KWG Update (PDF)</a>
     </div>
   </div>
@@ -133,6 +133,29 @@ aliases:
 
 <p class="kwg-conf-note">Session titles and times may change as preparation continues. Confirmed details will be published on this page and announced via the mailing list.</p>
 
+## Speakers
+
+<div class="kwg-conf-speakers">
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="kiyoung-sung.png" alt="Kiyoung Sung">
+    <div class="kwg-conf-speaker__name">Kiyoung Sung, Patent Attorney</div>
+    <div class="kwg-conf-speaker__role">CJ Corporation · Session 1</div>
+    <p class="kwg-conf-speaker__bio">Open source and patent management for CJ Group.</p>
+  </div>
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="byeongseok-choi.png" alt="Byeongseok Choi">
+    <div class="kwg-conf-speaker__name">Byeongseok Choi, General Manager</div>
+    <div class="kwg-conf-speaker__role">CJ OliveNetworks · Session 2</div>
+    <p class="kwg-conf-speaker__bio">Runs the open source management system for CJ Group.</p>
+  </div>
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="haksung-jang.png" alt="Haksung Jang">
+    <div class="kwg-conf-speaker__name">Haksung Jang, Manager</div>
+    <div class="kwg-conf-speaker__role">SK telecom · Session 3</div>
+    <p class="kwg-conf-speaker__bio">Open Source Program Manager at SK telecom and OpenChain Ambassador.</p>
+  </div>
+</div>
+
 ## Group Discussion Topics {#group-topics}
 
 Common topics for the 15:10–15:55 group discussion. Each group may pick one or two topics of most interest and go deeper.
@@ -158,29 +181,6 @@ Common topics for the 15:10–15:55 group discussion. Each group may pick one or
 ## Dinner After the Meeting
 
 A dinner gathering follows the regular meeting. Attendance is optional, and details will be announced via the mailing list.
-
-## Speakers
-
-<div class="kwg-conf-speakers">
-  <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" loading="lazy" src="kiyoung-sung.png" alt="Kiyoung Sung">
-    <div class="kwg-conf-speaker__name">Kiyoung Sung, Patent Attorney</div>
-    <div class="kwg-conf-speaker__role">CJ Corporation · Session 1</div>
-    <p class="kwg-conf-speaker__bio">Open source and patent management for CJ Group.</p>
-  </div>
-  <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" loading="lazy" src="byeongseok-choi.png" alt="Byeongseok Choi">
-    <div class="kwg-conf-speaker__name">Byeongseok Choi, General Manager</div>
-    <div class="kwg-conf-speaker__role">CJ OliveNetworks · Session 2</div>
-    <p class="kwg-conf-speaker__bio">Runs the open source management system for CJ Group.</p>
-  </div>
-  <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" loading="lazy" src="haksung-jang.png" alt="Haksung Jang">
-    <div class="kwg-conf-speaker__name">Haksung Jang, Manager</div>
-    <div class="kwg-conf-speaker__role">SK telecom · Session 3</div>
-    <p class="kwg-conf-speaker__bio">Open Source Program Manager at SK telecom and OpenChain Ambassador.</p>
-  </div>
-</div>
 
 ## Sponsor
 

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -73,7 +73,7 @@ aliases:
     <div class="kwg-conf-tl__marker"></div>
     <div class="kwg-conf-tl__body">
       <div class="kwg-conf-tl__title">OpenChain Updates</div>
-      <div class="kwg-conf-tl__by">Mary Wang, Executive Director · Linux Foundation / 운영진 · OpenChain Project (글로벌 업데이트)</div>
+      <div class="kwg-conf-tl__by">Mary Wang, Executive Director · Linux Foundation / 운영진</div>
       <a class="kwg-conf-tl__slide" href="https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/31th-kwg-update-2026q3.pdf" target="_blank" rel="noopener">KWG 업데이트 (PDF)</a>
     </div>
   </div>
@@ -133,6 +133,29 @@ aliases:
 
 <p class="kwg-conf-note">세션 제목과 시간은 준비 상황에 따라 조정될 수 있습니다. 확정 내용은 이 페이지와 메일링리스트로 안내드립니다.</p>
 
+## 발표자 소개
+
+<div class="kwg-conf-speakers">
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="kiyoung-sung.png" alt="성기영 변리사">
+    <div class="kwg-conf-speaker__name">성기영 변리사</div>
+    <div class="kwg-conf-speaker__role">CJ주식회사 · Session 1</div>
+    <p class="kwg-conf-speaker__bio">CJ그룹 오픈소스/특허 관리</p>
+  </div>
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="byeongseok-choi.png" alt="최병석 부장">
+    <div class="kwg-conf-speaker__name">최병석 부장</div>
+    <div class="kwg-conf-speaker__role">CJ올리브네트웍스 · Session 2</div>
+    <p class="kwg-conf-speaker__bio">CJ그룹 오픈소스 관리 시스템 운영담당</p>
+  </div>
+  <div class="kwg-conf-speaker">
+    <img class="kwg-conf-speaker__photo" loading="lazy" src="haksung-jang.png" alt="장학성 매니저">
+    <div class="kwg-conf-speaker__name">장학성 매니저</div>
+    <div class="kwg-conf-speaker__role">SK텔레콤 · Session 3</div>
+    <p class="kwg-conf-speaker__bio">SK텔레콤 오픈소스 프로그램 매니저, OpenChain Ambassador</p>
+  </div>
+</div>
+
 ## 그룹 토의 주제 {#group-topics}
 
 15:10–15:55 그룹 토의에서 다루는 공통 주제입니다. 조별로 관심 높은 1~2개를 골라 깊게 논의해도 됩니다.
@@ -158,29 +181,6 @@ aliases:
 ## 모임 후 저녁 식사
 
 정기 모임이 끝난 뒤 저녁 식사 자리를 마련합니다. 참석은 자유이며, 신청 방법은 메일링리스트로 안내드립니다.
-
-## 발표자 소개
-
-<div class="kwg-conf-speakers">
-  <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" loading="lazy" src="kiyoung-sung.png" alt="성기영 변리사">
-    <div class="kwg-conf-speaker__name">성기영 변리사</div>
-    <div class="kwg-conf-speaker__role">CJ주식회사 · Session 1</div>
-    <p class="kwg-conf-speaker__bio">CJ그룹 오픈소스/특허 관리</p>
-  </div>
-  <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" loading="lazy" src="byeongseok-choi.png" alt="최병석 부장">
-    <div class="kwg-conf-speaker__name">최병석 부장</div>
-    <div class="kwg-conf-speaker__role">CJ올리브네트웍스 · Session 2</div>
-    <p class="kwg-conf-speaker__bio">CJ그룹 오픈소스 관리 시스템 운영담당</p>
-  </div>
-  <div class="kwg-conf-speaker">
-    <img class="kwg-conf-speaker__photo" loading="lazy" src="haksung-jang.png" alt="장학성 매니저">
-    <div class="kwg-conf-speaker__name">장학성 매니저</div>
-    <div class="kwg-conf-speaker__role">SK텔레콤 · Session 3</div>
-    <p class="kwg-conf-speaker__bio">SK텔레콤 오픈소스 프로그램 매니저, OpenChain Ambassador</p>
-  </div>
-</div>
 
 ## Sponsor
 


### PR DESCRIPTION
## Summary
- 발표자 소개 단락을 아젠다 바로 아래로 이동 (ko/en)
- OpenChain Updates 항목의 "OpenChain Project (글로벌 업데이트/global update)" 표기 제거

## Test plan
- [x] npm run build 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K87LG4CKWa1gpqu2dX12SR