### PR TITLE
feat: 31차 미팅 페이지에 사진 앨범 추가

### DIFF
--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -188,3 +188,7 @@ A dinner gathering follows the regular meeting. Attendance is optional, and deta
   <span class="kwg-conf-sponsor__label">Sponsored by</span>
   <img src="../../../../images/content/about/logo/cj.png" alt="CJ">
 </div>
+
+## Album
+
+<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/72177720335516117" title="[2026 September] OpenChain Korea Work Group in CJ"><img src="https://live.staticflickr.com/65535/55516924083_4b364c5ce4_h.jpg" width="1200" height="1600" alt="[2026 September] OpenChain Korea Work Group in CJ"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -188,3 +188,7 @@ aliases:
   <span class="kwg-conf-sponsor__label">이번 미팅 후원</span>
   <img src="../../../images/content/about/logo/cj.png" alt="CJ">
 </div>
+
+## Album
+
+<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/72177720335516117" title="[2026 September] OpenChain Korea Work Group in CJ"><img src="https://live.staticflickr.com/65535/55516924083_4b364c5ce4_h.jpg" width="1200" height="1600" alt="[2026 September] OpenChain Korea Work Group in CJ"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>


### PR DESCRIPTION
## 요약
- 31차 미팅(CJ) 페이지 ko/en 양쪽에 Flickr 사진 앨범 임베드 추가
- 30차와 동일한 크기 등급(_h, 긴 변 1600px)으로 맞춤, 세로 사진 비율에 맞춰 1200x1600으로 계산

## 테스트
- [x] npm run build 성공
- [x] .claude/gate.sh 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABA7w7yX17HQHRnDFAZE6K