### PR TITLE
fix: 31차 미팅 앨범 사진 URL·사이즈 정정

### DIFF
--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -191,4 +191,4 @@ A dinner gathering follows the regular meeting. Attendance is optional, and deta
 
 ## Album
 
-<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/72177720335516117" title="[2026 September] OpenChain Korea Work Group in CJ"><img src="https://live.staticflickr.com/65535/55516924083_4b364c5ce4_h.jpg" width="1200" height="1600" alt="[2026 September] OpenChain Korea Work Group in CJ"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/72177720335516117" title="[2026 September] OpenChain Korea Work Group in CJ"><img src="https://live.staticflickr.com/65535/55516924083_4b364c5ce4_b.jpg" width="1024" height="576" alt="[2026 September] OpenChain Korea Work Group in CJ"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -191,4 +191,4 @@ aliases:
 
 ## Album
 
-<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/72177720335516117" title="[2026 September] OpenChain Korea Work Group in CJ"><img src="https://live.staticflickr.com/65535/55516924083_4b364c5ce4_h.jpg" width="1200" height="1600" alt="[2026 September] OpenChain Korea Work Group in CJ"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/72177720335516117" title="[2026 September] OpenChain Korea Work Group in CJ"><img src="https://live.staticflickr.com/65535/55516924083_4b364c5ce4_b.jpg" width="1024" height="576" alt="[2026 September] OpenChain Korea Work Group in CJ"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>


### PR DESCRIPTION
## 요약
- PR #374에서 넣은 Flickr 이미지 URL이 실제로는 410(Gone)이라 깨져 있었음
- 실제 서빙되는 가장 큰 사이즈(_b, 1024x576)로 교체

## 배경
- 원본 사진은 가로 16:9(800x450)인데, 사용자가 전달한 embed 코드의 width/height(768x1024)는 실제 이미지와 맞지 않았음
- 30차와 같은 등급인 _h(1600)로 URL을 바꿨으나 이 사진은 _h/_k/원본 다운로드가 막혀 있어(410) 존재하지 않는 URL이었음
- Chrome으로 배포된 페이지를 직접 확인하다가 깨진 이미지를 발견해 정정

## 테스트
- [x] curl로 _b URL 200 확인, 다운로드해 실제 픽셀 크기(1024x576) 확인
- [x] npm run build 성공
- [x] .claude/gate.sh 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpdJ4r2Mt5QfxT8GMGQ5HC