### PR TITLE
feat: 31차 미팅 페이지에 OpenChain Updates 글로벌 동향 추가

### DIFF
--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -133,6 +133,22 @@ aliases:
 
 <p class="kwg-conf-note">Session titles and times may change as preparation continues. Confirmed details will be published on this page and announced via the mailing list.</p>
 
+## OpenChain Updates: Global Highlights
+
+During the OpenChain Updates segment, Mary Wang, Executive Director of the Linux Foundation, joined remotely to share global highlights.
+
+### Recent Events and Community News
+
+The OpenChain Community Day was successfully held, followed by OSPOlogy and the OSPO Summit.
+
+### OpenChain CRA Requirement & Checklist
+
+RC1 (Release Candidate 1) of the [OpenChain CRA Requirement & Checklist](https://openchainproject.org/cracompliance), which supports compliance with the EU Cyber Resilience Act (CRA), has been released for review, with Version 1.0 targeted for September 11. Many companies and OpenChain partners have shown strong interest in the checklist and would like to collaborate as a next step. The document is available in the [GitHub CRA-Compliance repository](https://github.com/OpenChain-Project/CRA-Compliance).
+
+### SBOM Quality Guide and Automotive SBOM Framework
+
+The [SBOM Quality Guide](https://github.com/OpenChain-Project/SBOM-wg/blob/main/Cross-Industry-SBOM-Quality-Guide/en/Cross-Industry-SBOM-Quality-Guide.md) has received several PRs after the public review comment period, and Kobotasan and the community continue to work on it. The [Automotive SBOM framework](https://github.com/OpenChain-Project/Automotive-SBOM) 1.1 is open for public review, with a PR release planned for October.
+
 ## Speakers
 
 <div class="kwg-conf-speakers">

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -133,6 +133,22 @@ aliases:
 
 <p class="kwg-conf-note">세션 제목과 시간은 준비 상황에 따라 조정될 수 있습니다. 확정 내용은 이 페이지와 메일링리스트로 안내드립니다.</p>
 
+## OpenChain Updates: 글로벌 동향
+
+OpenChain Updates 시간에는 Linux Foundation 총괄 디렉터 Mary Wang이 원격으로 참여해 글로벌 동향을 공유했습니다.
+
+### 최근 행사와 커뮤니티 소식
+
+OpenChain Community Day가 성공적으로 열렸고, 뒤이어 OSPOlogy와 OSPO Summit도 마무리됐습니다.
+
+### OpenChain CRA Requirement & Checklist
+
+EU 사이버 복원력법(CRA, Cyber Resilience Act) 대응을 위한 [OpenChain CRA Requirement & Checklist](https://openchainproject.org/cracompliance)의 RC1(Release Candidate 1)이 공개돼 검토를 받고 있으며, 9월 11일 버전 1.0 출시를 목표로 하고 있습니다. 많은 기업과 OpenChain 파트너가 이 체크리스트에 강한 관심을 보이며 다음 단계로 협업을 희망하고 있습니다. 문서는 [GitHub CRA-Compliance 저장소](https://github.com/OpenChain-Project/CRA-Compliance)에서 확인할 수 있습니다.
+
+### SBOM 품질 가이드와 자동차 SBOM 프레임워크
+
+[SBOM 품질 가이드](https://github.com/OpenChain-Project/SBOM-wg/blob/main/Cross-Industry-SBOM-Quality-Guide/en/Cross-Industry-SBOM-Quality-Guide.md)는 공개 검토 의견을 받은 뒤 여러 건의 PR이 올라왔고, Kobotasan을 비롯한 커뮤니티가 계속 작업하고 있습니다. [Automotive SBOM 프레임워크](https://github.com/OpenChain-Project/Automotive-SBOM) 1.1 버전은 공개 검토가 진행 중이며, 10월 중 PR 릴리스가 예정돼 있습니다.
+
 ## 발표자 소개
 
 <div class="kwg-conf-speakers">


### PR DESCRIPTION
## 요약
- 31차 미팅(CJ) 아젠다에는 있었지만 빠져 있던 "OpenChain Updates: 글로벌 동향" 섹션을 ko/en 양쪽에 추가
- Mary Wang이 공유한 내용(Community Day·OSPOlogy/OSPO Summit, CRA Requirement & Checklist RC1, SBOM 품질 가이드, Automotive SBOM 프레임워크 1.1)을 30차 형식(개요 문단 + ### 소제목)에 맞춰 정리
- openchainproject.org 사이트에 실제 존재하는 자료만 링크로 연결(CRA 체크리스트: openchainproject.org/cracompliance + GitHub CRA-Compliance, SBOM 품질 가이드: GitHub SBOM-wg, Automotive SBOM: GitHub Automotive-SBOM). Community Day·OSPO Summit은 OpenChain 사이트에 해당 글이 없어 링크 없이 서술만 함

## 테스트
- [x] ko-style-lint 통과
- [x] npm run build 성공
- [x] .claude/gate.sh 통과
- [x] 링크된 URL 전부 curl로 200 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpdJ4r2Mt5QfxT8GMGQ5HC