### PR TITLE
fix: OpenChain Updates 섹션을 발표자 소개 하위로 이동, 목록형으로 정리

### DIFF
--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -126,33 +126,14 @@ aliases:
   </div>
 </div>
 
-## OpenChain Updates: Global Highlights
-
-During the OpenChain Updates segment, Mary Wang, Executive Director of the OpenChain Project, joined remotely to share global highlights. Alongside the current status of the standards, she positioned OpenChain as a key foundation linking compliance with the EU Cyber Resilience Act (CRA) and AI regulation.
-
-### Standards and Community Status
-
-OpenChain maintains two international standards, ISO 5230 and ISO 18974, adopted by more than 100 companies worldwide. It runs a 25-member governance board, and in 2026 Renesas joined as a new board member. The OpenChain China Work Group is set to launch, and new partners including OSCHINA have joined.
-
-### ISO 5230 Revision Status
-
-Under ISO rules, every standard must be renewed every five years. Five years on from ISO 5230:2020, the standard has been officially renewed without any change. Separately, the latest version reflecting minor modifications made over the past three years is 3.0; at the Q2 board meeting, the project decided to formally submit these to ISO. The designation 5230 will be retained, with a revision label applied only if necessary.
-
-### Next Chapter: CRA
-
-The EU Cyber Resilience Act (CRA) requires four things of companies selling software in the EU: Secure by Design, transparency over all open source components, continuous vulnerability management, and rapid reporting of security incidents. To respond, OpenChain formed a Business Operation Work Group, whose current topic is CRA. It is researching CRA-compliance gaps across organizations and identifying how OpenChain can support them.
-
-### Next Chapter: AI Governance
-
-OpenChain is also expanding into AI. It addresses the EU AI Act, integrates with ISO 42001, 42002, and 42003, and runs the OpenChain AI Work Group. The OpenChain AI SBOM Self Certification is also under way.
-
-### Also Worth Noting
-
-An OpenChain introduction video is planned for OCS (Open Compliance Summit) in December, and the "Adopt our standards" webpage has been updated. The OpenChain and Friends webinar series is ongoing. Organizations looking to adopt the standards can refer to the [OpenChain get-started page](https://openchainproject.org/get-started).
-
 ## Speakers
 
 <div class="kwg-conf-speakers">
+  <div class="kwg-conf-speaker">
+    <div class="kwg-conf-speaker__name">Mary Wang, Executive Director</div>
+    <div class="kwg-conf-speaker__role">OpenChain Project · OpenChain Updates</div>
+    <p class="kwg-conf-speaker__bio">Leads OpenChain Project standards and the global community.</p>
+  </div>
   <div class="kwg-conf-speaker">
     <img class="kwg-conf-speaker__photo" loading="lazy" src="heonkwan-ha.png" alt="Heonkwan Ha">
     <div class="kwg-conf-speaker__name">Heonkwan Ha, Manager</div>
@@ -172,6 +153,16 @@ An OpenChain introduction video is planned for OCS (Open Compliance Summit) in D
     <p class="kwg-conf-speaker__bio">Open source governance at KakaoBank, in-house IT policy, and internal/external audit response.</p>
   </div>
 </div>
+
+### OpenChain Updates: Global Highlights
+
+Highlights Mary Wang shared during the OpenChain Updates segment. She positioned OpenChain as a key foundation linking compliance with the EU Cyber Resilience Act (CRA) and AI regulation.
+
+- OpenChain maintains two international standards, ISO 5230 and ISO 18974, adopted by more than 100 companies worldwide. It runs a 25-member governance board, and in 2026 Renesas joined as a new board member. The OpenChain China Work Group is set to launch, and new partners including OSCHINA have joined.
+- Under ISO rules, every standard must be renewed every five years. ISO 5230:2020 has been officially renewed without any change, and the project decided at its Q2 board meeting to submit version 3.0, which reflects minor modifications made over the past three years, to ISO. The designation 5230 will be retained, with a revision label applied only if necessary.
+- The EU Cyber Resilience Act (CRA) requires Secure by Design, transparency over all open source components, continuous vulnerability management, and rapid reporting of security incidents. OpenChain formed a Business Operation Work Group to research CRA-compliance gaps across organizations and identify how it can help.
+- In the AI space, OpenChain is addressing the EU AI Act, integrating with ISO 42001, 42002, and 42003, running the OpenChain AI Work Group, and advancing the OpenChain AI SBOM Self Certification.
+- An OpenChain introduction video is planned for OCS (Open Compliance Summit) in December, and the "Adopt our standards" webpage has been updated. The OpenChain and Friends webinar series is ongoing. Organizations looking to adopt the standards can refer to the [OpenChain get-started page](https://openchainproject.org/get-started).
 
 ## Sponsor
 

--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -133,25 +133,14 @@ aliases:
 
 <p class="kwg-conf-note">Session titles and times may change as preparation continues. Confirmed details will be published on this page and announced via the mailing list.</p>
 
-## OpenChain Updates: Global Highlights
-
-During the OpenChain Updates segment, Mary Wang, Executive Director of the Linux Foundation, joined remotely to share global highlights.
-
-### Recent Events and Community News
-
-The OpenChain Community Day was successfully held, followed by OSPOlogy and the OSPO Summit.
-
-### OpenChain CRA Requirement & Checklist
-
-RC1 (Release Candidate 1) of the [OpenChain CRA Requirement & Checklist](https://openchainproject.org/cracompliance), which supports compliance with the EU Cyber Resilience Act (CRA), has been released for review, with Version 1.0 targeted for September 11. Many companies and OpenChain partners have shown strong interest in the checklist and would like to collaborate as a next step. The document is available in the [GitHub CRA-Compliance repository](https://github.com/OpenChain-Project/CRA-Compliance).
-
-### SBOM Quality Guide and Automotive SBOM Framework
-
-The [SBOM Quality Guide](https://github.com/OpenChain-Project/SBOM-wg/blob/main/Cross-Industry-SBOM-Quality-Guide/en/Cross-Industry-SBOM-Quality-Guide.md) has received several PRs after the public review comment period, and Kobotasan and the community continue to work on it. The [Automotive SBOM framework](https://github.com/OpenChain-Project/Automotive-SBOM) 1.1 is open for public review, with a PR release planned for October.
-
 ## Speakers
 
 <div class="kwg-conf-speakers">
+  <div class="kwg-conf-speaker">
+    <div class="kwg-conf-speaker__name">Mary Wang, Executive Director</div>
+    <div class="kwg-conf-speaker__role">Linux Foundation · OpenChain Updates</div>
+    <p class="kwg-conf-speaker__bio">Leads OpenChain Project standards and the global community.</p>
+  </div>
   <div class="kwg-conf-speaker">
     <img class="kwg-conf-speaker__photo" loading="lazy" src="kiyoung-sung.png" alt="Kiyoung Sung">
     <div class="kwg-conf-speaker__name">Kiyoung Sung, Patent Attorney</div>
@@ -171,6 +160,15 @@ The [SBOM Quality Guide](https://github.com/OpenChain-Project/SBOM-wg/blob/main/
     <p class="kwg-conf-speaker__bio">Open Source Program Manager at SK telecom and OpenChain Ambassador.</p>
   </div>
 </div>
+
+### OpenChain Updates: Global Highlights
+
+Highlights Mary Wang shared during the OpenChain Updates segment.
+
+- The OpenChain Community Day, OSPOlogy, and the OSPO Summit were all successfully completed.
+- RC1 of the [OpenChain CRA Requirement & Checklist](https://openchainproject.org/cracompliance) has been released for review, with Version 1.0 targeted for September 11. Many companies and OpenChain partners have shown strong interest and would like to collaborate. ([GitHub](https://github.com/OpenChain-Project/CRA-Compliance))
+- The [SBOM Quality Guide](https://github.com/OpenChain-Project/SBOM-wg/blob/main/Cross-Industry-SBOM-Quality-Guide/en/Cross-Industry-SBOM-Quality-Guide.md) has received several PRs after the public review comment period, and Kobotasan and the community continue to work on it.
+- The [Automotive SBOM framework](https://github.com/OpenChain-Project/Automotive-SBOM) 1.1 is open for public review, with a PR release planned for October.
 
 ## Group Discussion Topics {#group-topics}
 

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -127,33 +127,14 @@ aliases:
   </div>
 </div>
 
-## OpenChain Updates: 글로벌 동향
-
-OpenChain Updates 시간에는 OpenChain Project 총괄 디렉터 Mary Wang이 원격으로 참여해 글로벌 동향을 공유했습니다. 표준 운영 현황과 함께, OpenChain을 CRA(EU 사이버 복원력법)와 AI 규제 대응을 연결하는 핵심 기반으로 설명했습니다.
-
-### 표준과 커뮤니티 현황
-
-ISO 5230과 ISO 18974 두 국제표준을 운영하며 전 세계 100여 개 기업이 채택했습니다. 25인 거버넌스 보드를 두고 있고, 2026년에는 Renesas가 신규 보드 멤버로 합류했습니다. OpenChain China Work Group 출범이 예정돼 있으며, OSCHINA를 포함한 신규 파트너도 합류했습니다.
-
-### ISO 5230 개정 현황
-
-ISO 규정상 모든 표준은 5년마다 갱신해야 합니다. ISO 5230:2020이 5년을 지나 내용 변경 없이 공식 갱신됐습니다. 한편 지난 3년간 반영한 소규모 수정사항을 담은 최신본은 3.0이며, 2분기 보드 회의에서 이를 ISO에 공식 제출하기로 결정했습니다. 표준 명칭은 5230을 그대로 유지하고, 필요한 경우에만 개정 라벨을 붙이기로 했습니다.
-
-### 다음 과제: CRA 대응
-
-EU 사이버 복원력법(CRA, Cyber Resilience Act)은 EU에 소프트웨어를 판매하는 기업에 네 가지를 요구합니다. 설계 단계부터의 보안(Secure by Design), 모든 오픈소스 구성요소에 대한 투명성, 지속적인 취약점 관리, 보안 사고의 신속한 보고입니다. OpenChain은 이에 대응하기 위해 Business Operation Work Group을 신설했고, 현재 주제가 CRA입니다. 조직별 CRA 준수 격차를 조사하고 OpenChain이 지원할 수 있는 방안을 찾고 있습니다.
-
-### 다음 과제: AI 거버넌스
-
-AI 영역으로도 범위를 넓히고 있습니다. EU AI Act에 대응하고 ISO 42001, 42002, 42003과 연계하며 OpenChain AI Work Group을 운영합니다. OpenChain AI SBOM 자가 인증(Self Certification)도 추진하고 있습니다.
-
-### 그 밖의 소식
-
-12월 OCS(Open Compliance Summit)에서 OpenChain 소개 영상을 제작할 예정이며, 'Adopt our standards' 웹페이지를 개편했습니다. OpenChain and Friends 웨비나도 진행 중입니다. 표준 채택을 시작하려는 조직은 [OpenChain 안내 페이지](https://openchainproject.org/get-started)를 참고하시기 바랍니다.
-
 ## 발표자 소개
 
 <div class="kwg-conf-speakers">
+  <div class="kwg-conf-speaker">
+    <div class="kwg-conf-speaker__name">Mary Wang, Executive Director</div>
+    <div class="kwg-conf-speaker__role">OpenChain Project · OpenChain Updates</div>
+    <p class="kwg-conf-speaker__bio">OpenChain Project 표준과 글로벌 커뮤니티를 총괄합니다.</p>
+  </div>
   <div class="kwg-conf-speaker">
     <img class="kwg-conf-speaker__photo" loading="lazy" src="heonkwan-ha.png" alt="하헌관 매니저">
     <div class="kwg-conf-speaker__name">하헌관 매니저</div>
@@ -173,6 +154,16 @@ AI 영역으로도 범위를 넓히고 있습니다. EU AI Act에 대응하고 I
     <p class="kwg-conf-speaker__bio">카카오뱅크 오픈소스 거버넌스, 사내 IT 업무 관련 정책 담당, 내외부감사 대응</p>
   </div>
 </div>
+
+### OpenChain Updates: 글로벌 동향
+
+OpenChain Updates 시간에 Mary Wang이 공유한 내용입니다. OpenChain을 CRA(EU 사이버 복원력법)와 AI 규제 대응을 연결하는 핵심 기반으로 설명했습니다.
+
+- ISO 5230과 ISO 18974 두 국제표준을 운영하며 전 세계 100여 개 기업이 채택했습니다. 25인 거버넌스 보드를 두고 있고, 2026년 Renesas가 신규 보드 멤버로 합류했습니다. OpenChain China Work Group 출범이 예정돼 있으며, OSCHINA를 포함한 신규 파트너도 합류했습니다.
+- ISO 규정상 모든 표준은 5년마다 갱신해야 합니다. ISO 5230:2020이 내용 변경 없이 공식 갱신됐고, 지난 3년간 반영한 소규모 수정사항을 담은 3.0을 2분기 보드 회의에서 ISO에 공식 제출하기로 결정했습니다. 표준 명칭은 5230을 유지하고, 필요한 경우에만 개정 라벨을 붙이기로 했습니다.
+- EU 사이버 복원력법(CRA, Cyber Resilience Act)은 설계 단계부터의 보안(Secure by Design), 오픈소스 구성요소 투명성, 지속적인 취약점 관리, 보안 사고의 신속한 보고를 요구합니다. OpenChain은 Business Operation Work Group을 신설해 조직별 CRA 준수 격차를 조사하고 지원 방안을 찾고 있습니다.
+- AI 영역에서는 EU AI Act 대응, ISO 42001·42002·42003과의 연계, OpenChain AI Work Group 운영, OpenChain AI SBOM 자가 인증(Self Certification) 추진을 진행하고 있습니다.
+- 12월 OCS(Open Compliance Summit)에서 OpenChain 소개 영상을 제작할 예정이며, 'Adopt our standards' 웹페이지를 개편했습니다. OpenChain and Friends 웨비나도 진행 중입니다. 표준 채택을 시작하려는 조직은 [OpenChain 안내 페이지](https://openchainproject.org/get-started)를 참고하시기 바랍니다.
 
 ## Sponsor
 

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -133,25 +133,14 @@ aliases:
 
 <p class="kwg-conf-note">세션 제목과 시간은 준비 상황에 따라 조정될 수 있습니다. 확정 내용은 이 페이지와 메일링리스트로 안내드립니다.</p>
 
-## OpenChain Updates: 글로벌 동향
-
-OpenChain Updates 시간에는 Linux Foundation 총괄 디렉터 Mary Wang이 원격으로 참여해 글로벌 동향을 공유했습니다.
-
-### 최근 행사와 커뮤니티 소식
-
-OpenChain Community Day가 성공적으로 열렸고, 뒤이어 OSPOlogy와 OSPO Summit도 마무리됐습니다.
-
-### OpenChain CRA Requirement & Checklist
-
-EU 사이버 복원력법(CRA, Cyber Resilience Act) 대응을 위한 [OpenChain CRA Requirement & Checklist](https://openchainproject.org/cracompliance)의 RC1(Release Candidate 1)이 공개돼 검토를 받고 있으며, 9월 11일 버전 1.0 출시를 목표로 하고 있습니다. 많은 기업과 OpenChain 파트너가 이 체크리스트에 강한 관심을 보이며 다음 단계로 협업을 희망하고 있습니다. 문서는 [GitHub CRA-Compliance 저장소](https://github.com/OpenChain-Project/CRA-Compliance)에서 확인할 수 있습니다.
-
-### SBOM 품질 가이드와 자동차 SBOM 프레임워크
-
-[SBOM 품질 가이드](https://github.com/OpenChain-Project/SBOM-wg/blob/main/Cross-Industry-SBOM-Quality-Guide/en/Cross-Industry-SBOM-Quality-Guide.md)는 공개 검토 의견을 받은 뒤 여러 건의 PR이 올라왔고, Kobotasan을 비롯한 커뮤니티가 계속 작업하고 있습니다. [Automotive SBOM 프레임워크](https://github.com/OpenChain-Project/Automotive-SBOM) 1.1 버전은 공개 검토가 진행 중이며, 10월 중 PR 릴리스가 예정돼 있습니다.
-
 ## 발표자 소개
 
 <div class="kwg-conf-speakers">
+  <div class="kwg-conf-speaker">
+    <div class="kwg-conf-speaker__name">Mary Wang, Executive Director</div>
+    <div class="kwg-conf-speaker__role">Linux Foundation · OpenChain Updates</div>
+    <p class="kwg-conf-speaker__bio">OpenChain Project 표준과 글로벌 커뮤니티를 총괄합니다.</p>
+  </div>
   <div class="kwg-conf-speaker">
     <img class="kwg-conf-speaker__photo" loading="lazy" src="kiyoung-sung.png" alt="성기영 변리사">
     <div class="kwg-conf-speaker__name">성기영 변리사</div>
@@ -171,6 +160,15 @@ EU 사이버 복원력법(CRA, Cyber Resilience Act) 대응을 위한 [OpenChain
     <p class="kwg-conf-speaker__bio">SK텔레콤 오픈소스 프로그램 매니저, OpenChain Ambassador</p>
   </div>
 </div>
+
+### OpenChain Updates: 글로벌 동향
+
+OpenChain Updates 시간에 Mary Wang이 공유한 내용입니다.
+
+- OpenChain Community Day와 OSPOlogy, OSPO Summit이 성공적으로 마무리됐습니다.
+- [OpenChain CRA Requirement & Checklist](https://openchainproject.org/cracompliance)의 RC1이 공개돼 검토 중이며, 9월 11일 버전 1.0 출시를 목표로 합니다. 많은 기업과 OpenChain 파트너가 관심을 보이며 협업을 희망하고 있습니다. ([GitHub](https://github.com/OpenChain-Project/CRA-Compliance))
+- [SBOM 품질 가이드](https://github.com/OpenChain-Project/SBOM-wg/blob/main/Cross-Industry-SBOM-Quality-Guide/en/Cross-Industry-SBOM-Quality-Guide.md)는 공개 검토 의견을 받은 뒤 여러 PR이 올라왔고, Kobotasan을 비롯한 커뮤니티가 계속 작업하고 있습니다.
+- [Automotive SBOM 프레임워크](https://github.com/OpenChain-Project/Automotive-SBOM) 1.1 버전은 공개 검토 중이며, 10월 중 PR 릴리스가 예정돼 있습니다.
 
 ## 그룹 토의 주제 {#group-topics}
 


### PR DESCRIPTION
## 요약
- 30·31차 미팅 페이지에서 "OpenChain Updates: 글로벌 동향"을 "발표자 소개"의 하위 섹션(###)으로 이동
- Mary Wang(Executive Director)을 발표자 소개 카드에 추가(사진 없음)
- 서술형 문단이던 내용을 목록형(불릿)으로 정리

## 참고
- Mary Wang 발표자 카드에는 인물 사진이 없어 이미지 없이 이름·소속·소개만 표기
- 30차는 기존 아젠다상 소속 표기("OpenChain Project")를, 31차는 기존 표기("Linux Foundation")를 각각 그대로 따름(페이지 내부 일관성 유지)

## 테스트
- [x] ko-style-lint 통과
- [x] npm run build 성공
- [x] .claude/gate.sh 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpdJ4r2Mt5QfxT8GMGQ5HC