### PR TITLE
feat: 32차 미팅(현대오토에버) 페이지 생성

### DIFF
--- a/content/en/meeting/2026/32th/_index.md
+++ b/content/en/meeting/2026/32th/_index.md
@@ -1,0 +1,39 @@
+---
+title: "32th Meeting"
+date: 2026-09-09T10:22:23+09:00
+weight: 32
+type: docs
+categories: ["meeting"]
+tags: [""]
+description: >
+  December 8, 2026 (Tue) (tentative) / Hyundai AutoEver
+draft: false
+---
+
+## Schedule
+
+* Schedule: 2026-12-08 (Tue) (tentative), time TBD
+* Venue: Hyundai AutoEver (Samseong-dong, Gangnam-gu, Seoul - https://www.google.com/maps/search/?api=1&query=Hyundai+AutoEver+Samseong-dong )
+
+<!--
+Slide upload instructions:
+1. Go to the GitHub Releases page:
+   https://github.com/OpenChain-Project/OpenChain-KWG/releases/tag/meeting-slides-2026
+   (create the tag if it doesn't exist yet)
+2. File naming rules:
+   - Letters, numbers, hyphens (-), underscores (_), and dots (.) only
+   - No spaces, Korean characters, or other special characters
+   - Recommended format: YYYYMMDD-speaker-topic-keyword.pdf
+3. Copy the download URL after uploading:
+   https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/filename.pdf
+4. Replace the link URL in the table above with the copied URL
+-->
+
+## Sponsor
+
+![](../../../../images/content/about/logo/hd_autoever.png)
+
+<!--
+Replace with the Flickr album embed code once it's created after the meeting.
+<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/ALBUM_ID" title="ALBUM_TITLE"><img src="THUMBNAIL_URL" width="1024" height="768" alt="ALBUM_TITLE"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+-->

--- a/content/ko/meeting/2026/32th/_index.md
+++ b/content/ko/meeting/2026/32th/_index.md
@@ -1,0 +1,54 @@
+---
+title: "32th Meeting"
+date: 2026-09-09T10:22:23+09:00
+weight: 32
+type: docs
+categories: ["meeting"]
+tags: [""]
+description: >
+  2026년 12월 8일 (화) (예정) / 현대오토에버
+draft: false
+---
+
+## 일정
+
+* 일정: 2026-12-08 (화) (예정), 시간 미정
+* 장소: 현대오토에버 (서울시 강남구 삼성동 - https://www.google.com/maps/search/?api=1&query=%ED%98%84%EB%8C%80%EC%98%A4%ED%86%A0%EC%97%90%EB%B2%84+%EC%82%BC%EC%84%B1%EB%8F%99 )
+
+<!-- ## 아젠다
+
+| Time        | Agenda                        | Speaker                          | Slide |
+|-------------|-------------------------------|----------------------------------|-------|
+| 00:00~00:00 | 웰컴 & 오프닝                 | 발표자, 소속                      | -     |
+| 00:00~00:00 | 발표 제목                     | 발표자, 소속                      | [pdf](https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-YYYY/파일명.pdf) |
+| 00:00~00:00 | 네트워킹                      | All                              | -     |
+
+## 발표자료
+
+| 제목 | 발표자 | 자료 |
+|---|---|---|
+| 발표 제목 | 발표자명 | [PDF](https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-YYYY/파일명.pdf) |
+-->
+
+<!--
+첨부파일 업로드 방법:
+1. GitHub Releases 페이지 접속:
+   https://github.com/OpenChain-Project/OpenChain-KWG/releases/tag/meeting-slides-2026
+   (태그가 없으면 새로 생성)
+2. 파일명 규칙 준수:
+   - 영문, 숫자, 하이픈(-), 언더스코어(_), 점(.)만 사용
+   - 공백·한글·특수문자 사용 금지
+   - 권장 형식: YYYYMMDD-발표자-주제키워드.pdf
+3. 업로드 후 다운로드 URL 복사:
+   https://github.com/OpenChain-Project/OpenChain-KWG/releases/download/meeting-slides-2026/파일명.pdf
+4. 위 표의 링크 URL을 복사한 URL로 교체
+-->
+
+## Sponsor
+
+![](../../../images/content/about/logo/hd_autoever.png)
+
+<!--
+미팅 후 Flickr 앨범이 생성되면 아래 embed 코드를 교체하세요.
+<a data-flickr-embed="true" href="https://www.flickr.com/photos/198570149@N05/albums/ALBUM_ID" title="ALBUM_TITLE"><img src="THUMBNAIL_URL" width="1024" height="768" alt="ALBUM_TITLE"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+-->


### PR DESCRIPTION
## 요약
- 32차 미팅 안내 페이지 생성(ko/en)
- 확정된 정보만 반영: 일정 2026-12-08(화, 예정) 시간 미정, 장소 현대오토에버(서울 강남구 삼성동)
- 아젠다·발표자·발표자료는 준비되는 대로 추가(현재는 archetype 형식의 주석 처리된 표만 포함)
- Sponsor 로고는 기존에 있던 hd_autoever.png 사용

## 참고
- 지도 링크는 정확한 사옥 주소(마천루 좌표) 확인 전이라 구글 지도 검색 링크로 연결. 정확한 주소·지도 링크는 확정되면 교체 필요
- 30·31차처럼 컨퍼런스 홍보형 레이아웃(`type: meeting` + `layout: landing`)은 아젠다·발표자가 정해진 뒤 전환 예정

## 테스트
- [x] ko-style-lint 통과
- [x] npm run build 성공
- [x] .claude/gate.sh 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpdJ4r2Mt5QfxT8GMGQ5HC