### PR TITLE
fix: Sponsor 단락을 아젠다 위로 이동

### DIFF
--- a/content/en/meeting/2026/30th/_index.md
+++ b/content/en/meeting/2026/30th/_index.md
@@ -51,6 +51,13 @@ aliases:
 - Organizations redefining open source governance scope after AI adoption
 - Teams preparing checklists and evidence for audits and inspections
 
+## Sponsor
+
+<div class="kwg-conf-sponsor">
+  <span class="kwg-conf-sponsor__label">Sponsored by</span>
+  <img src="../../../../images/content/about/logo/kakaobank.png" alt="KakaoBank">
+</div>
+
 ## Agenda
 
 <div class="kwg-conf-timeline">
@@ -164,13 +171,6 @@ Highlights Mary Wang shared during the OpenChain Updates segment. She positioned
 - The EU Cyber Resilience Act (CRA) requires Secure by Design, transparency over all open source components, continuous vulnerability management, and rapid reporting of security incidents. OpenChain formed a Business Operation Work Group to research CRA-compliance gaps across organizations and identify how it can help.
 - In the AI space, OpenChain is addressing the EU AI Act, integrating with ISO 42001, 42002, and 42003, running the OpenChain AI Work Group, and advancing the OpenChain AI SBOM Self Certification.
 - An OpenChain introduction video is planned for OCS (Open Compliance Summit) in December, and the "Adopt our standards" webpage has been updated. The OpenChain and Friends webinar series is ongoing. Organizations looking to adopt the standards can refer to the [OpenChain get-started page](https://openchainproject.org/get-started).
-
-## Sponsor
-
-<div class="kwg-conf-sponsor">
-  <span class="kwg-conf-sponsor__label">Sponsored by</span>
-  <img src="../../../../images/content/about/logo/kakaobank.png" alt="KakaoBank">
-</div>
 
 ## Album
 

--- a/content/en/meeting/2026/31th/_index.md
+++ b/content/en/meeting/2026/31th/_index.md
@@ -57,6 +57,13 @@ aliases:
 - Teams starting on software supply chain security or needing to verify SBOMs received from suppliers
 - Anyone who wants to hear other companies' cases and expand their practitioner network
 
+## Sponsor
+
+<div class="kwg-conf-sponsor">
+  <span class="kwg-conf-sponsor__label">Sponsored by</span>
+  <img src="../../../../images/content/about/logo/cj.png" alt="CJ">
+</div>
+
 ## Agenda
 
 <div class="kwg-conf-timeline">
@@ -196,13 +203,6 @@ Common topics for the 15:10–15:55 group discussion. Each group may pick one or
 ## Dinner After the Meeting
 
 A dinner gathering follows the regular meeting. Attendance is optional, and details will be announced via the mailing list.
-
-## Sponsor
-
-<div class="kwg-conf-sponsor">
-  <span class="kwg-conf-sponsor__label">Sponsored by</span>
-  <img src="../../../../images/content/about/logo/cj.png" alt="CJ">
-</div>
 
 ## Album
 

--- a/content/ko/meeting/2026/30th/_index.md
+++ b/content/ko/meeting/2026/30th/_index.md
@@ -52,6 +52,13 @@ aliases:
 - AI 도입 이후 오픈소스 거버넌스 범위를 재정의해야 하는 조직
 - 감사·점검 대응을 위한 체크리스트와 증적 관리가 필요한 팀
 
+## Sponsor
+
+<div class="kwg-conf-sponsor">
+  <span class="kwg-conf-sponsor__label">이번 미팅 후원</span>
+  <img src="../../../images/content/about/logo/kakaobank.png" alt="KakaoBank">
+</div>
+
 ## 아젠다
 
 <div class="kwg-conf-timeline">
@@ -165,13 +172,6 @@ OpenChain Updates 시간에 Mary Wang이 공유한 내용입니다. OpenChain을
 - EU 사이버 복원력법(CRA, Cyber Resilience Act)은 설계 단계부터의 보안(Secure by Design), 오픈소스 구성요소 투명성, 지속적인 취약점 관리, 보안 사고의 신속한 보고를 요구합니다. OpenChain은 Business Operation Work Group을 신설해 조직별 CRA 준수 격차를 조사하고 지원 방안을 찾고 있습니다.
 - AI 영역에서는 EU AI Act 대응, ISO 42001·42002·42003과의 연계, OpenChain AI Work Group 운영, OpenChain AI SBOM 자가 인증(Self Certification) 추진을 진행하고 있습니다.
 - 12월 OCS(Open Compliance Summit)에서 OpenChain 소개 영상을 제작할 예정이며, 'Adopt our standards' 웹페이지를 개편했습니다. OpenChain and Friends 웨비나도 진행 중입니다. 표준 채택을 시작하려는 조직은 [OpenChain 안내 페이지](https://openchainproject.org/get-started)를 참고하시기 바랍니다.
-
-## Sponsor
-
-<div class="kwg-conf-sponsor">
-  <span class="kwg-conf-sponsor__label">이번 미팅 후원</span>
-  <img src="../../../images/content/about/logo/kakaobank.png" alt="KakaoBank">
-</div>
 
 ## Album
 

--- a/content/ko/meeting/2026/31th/_index.md
+++ b/content/ko/meeting/2026/31th/_index.md
@@ -57,6 +57,13 @@ aliases:
 - 소프트웨어 공급망 보안 대응을 시작했거나 공급사에서 받는 SBOM을 검증해야 하는 팀
 - 다른 회사의 사례를 듣고 실무 네트워크를 넓히고 싶은 분
 
+## Sponsor
+
+<div class="kwg-conf-sponsor">
+  <span class="kwg-conf-sponsor__label">이번 미팅 후원</span>
+  <img src="../../../images/content/about/logo/cj.png" alt="CJ">
+</div>
+
 ## 아젠다
 
 <div class="kwg-conf-timeline">
@@ -196,13 +203,6 @@ OpenChain Updates 시간에 Mary Wang이 공유한 내용입니다.
 ## 모임 후 저녁 식사
 
 정기 모임이 끝난 뒤 저녁 식사 자리를 마련합니다. 참석은 자유이며, 신청 방법은 메일링리스트로 안내드립니다.
-
-## Sponsor
-
-<div class="kwg-conf-sponsor">
-  <span class="kwg-conf-sponsor__label">이번 미팅 후원</span>
-  <img src="../../../images/content/about/logo/cj.png" alt="CJ">
-</div>
 
 ## Album
 


### PR DESCRIPTION
## 요약
- 30·31차 미팅 페이지에서 "Sponsor" 단락을 "아젠다" 위(이런 분께 추천 다음)로 이동
- 32차는 아젠다가 아직 주석 처리 상태라 Sponsor가 이미 그 위치에 있어 변경 없음

## 테스트
- [x] ko-style-lint 통과
- [x] npm run build 성공
- [x] .claude/gate.sh 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpdJ4r2Mt5QfxT8GMGQ5HC